### PR TITLE
fix(desktop): await renderer RPC peer teardown before reconnect and shutdown

### DIFF
--- a/apps/desktop/src/main/electron/main-window.ts
+++ b/apps/desktop/src/main/electron/main-window.ts
@@ -3,12 +3,13 @@ import url from "node:url";
 
 import { is } from "@electron-toolkit/utils";
 import { Context, Effect, Layer, Scope } from "effect";
-import { BrowserWindow, shell, type WebContents } from "electron";
+import { BrowserWindow, shell } from "electron";
 
 import icon from "../../../resources/icon.png?asset";
 import { DesktopConfig } from "../desktop-config";
 import { APP_ORIGIN, registerAppProtocol } from "./app-protocol";
 import { RendererChannel } from "./renderer-channel";
+import { type ConnectRenderer, makeRendererLifecycle } from "./renderer-lifecycle";
 
 export class MainWindow extends Context.Service<
   MainWindow,
@@ -20,7 +21,7 @@ export class MainWindow extends Context.Service<
 
 export type MainWindowOptions = {
   readonly devUrl: string | undefined;
-  readonly connectRenderer: (webContents: WebContents) => () => Promise<void>;
+  readonly connectRenderer: ConnectRenderer;
 };
 
 function canOpenExternal(href: string): boolean {
@@ -37,13 +38,17 @@ export function makeMainWindow(
 ): Effect.Effect<MainWindow["Service"], never, Scope.Scope> {
   return Effect.gen(function* () {
     let mainWindow: BrowserWindow | undefined;
-    let disconnectRenderer: (() => Promise<void>) | undefined;
     const isE2E = process.env["VIBEST_E2E"] === "1";
 
-    const disconnectCurrentRenderer = (): void => {
-      const disconnect = disconnectRenderer;
-      disconnectRenderer = undefined;
-      if (disconnect) void disconnect();
+    const renderer = yield* makeRendererLifecycle(options.connectRenderer);
+    // Electron event callbacks are synchronous, so lifecycle transitions run
+    // on forked fibers carrying this Layer's context (for the logger). The
+    // lifecycle serializes them internally, and the shutdown finalizer below
+    // refuses late attachments, so a straggling fiber cannot attach a peer
+    // after disposal.
+    const context = yield* Effect.context<never>();
+    const forkRendererTransition = (transition: Effect.Effect<void>): void => {
+      Effect.runFork(Effect.provideContext(transition, context));
     };
 
     const target = is.dev && options.devUrl ? options.devUrl : `${APP_ORIGIN}/`;
@@ -77,11 +82,10 @@ export function makeMainWindow(
         if (!isE2E) window.show();
       });
       window.webContents.on("did-finish-load", () => {
-        disconnectCurrentRenderer();
-        disconnectRenderer = options.connectRenderer(window.webContents);
+        forkRendererTransition(renderer.replace(window.webContents));
       });
       window.on("closed", () => {
-        disconnectCurrentRenderer();
+        forkRendererTransition(renderer.detach);
         if (mainWindow === window) mainWindow = undefined;
       });
 
@@ -107,11 +111,14 @@ export function makeMainWindow(
     };
 
     yield* Effect.addFinalizer(() =>
-      Effect.sync(() => {
-        disconnectCurrentRenderer();
-        mainWindow?.destroy();
-        mainWindow = undefined;
-      }),
+      renderer.shutdown.pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            mainWindow?.destroy();
+            mainWindow = undefined;
+          }),
+        ),
+      ),
     );
 
     // Detached so ensureOpen stays fire-and-forget; the load outcome is only

--- a/apps/desktop/src/main/electron/renderer-channel.ts
+++ b/apps/desktop/src/main/electron/renderer-channel.ts
@@ -1,39 +1,42 @@
-import { Context } from "effect";
-import { MessageChannelMain, type MessagePortMain, type WebContents } from "electron";
+import { Context, Effect } from "effect";
+import { MessageChannelMain, type MessagePortMain } from "electron";
 
 import { DESKTOP_PORT_CHANNEL } from "../../shared/desktop-channel";
+import type { ConnectRenderer } from "./renderer-lifecycle";
 
 export type AttachMessagePort = (port: MessagePortMain) => () => Promise<void>;
 
 export class RendererChannel extends Context.Service<
   RendererChannel,
   {
-    readonly connect: (webContents: WebContents) => () => Promise<void>;
+    readonly connect: ConnectRenderer;
   }
 >()("desktop/RendererChannel") {}
 
+// Establishing a peer is a scoped acquisition: the release awaits the oRPC
+// detach promise before closing the port, so closing the Scope observes the
+// peer's full cleanup instead of firing it off untracked.
 export function makeRendererChannel(attachPort: AttachMessagePort): RendererChannel["Service"] {
   return {
-    connect: (webContents) => {
-      const { port1, port2 } = new MessageChannelMain();
-      const detach = attachPort(port1);
-      port1.start();
-
-      try {
-        webContents.postMessage(DESKTOP_PORT_CHANNEL, undefined, [port2]);
-      } catch (error) {
-        void detach();
-        port1.close();
-        throw error;
-      }
-
-      let closed = false;
-      return async () => {
-        if (closed) return;
-        closed = true;
-        await detach();
-        port1.close();
-      };
-    },
+    connect: (webContents) =>
+      Effect.gen(function* () {
+        const peer = yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            const { port1, port2 } = new MessageChannelMain();
+            const detach = attachPort(port1);
+            port1.start();
+            return { port1, port2, detach };
+          }),
+          (acquired) =>
+            Effect.promise(() => acquired.detach()).pipe(
+              Effect.ensuring(Effect.sync(() => acquired.port1.close())),
+            ),
+        );
+        // A failed handoff (e.g. destroyed webContents) fails the surrounding
+        // Scope, which runs the release above.
+        yield* Effect.try(() =>
+          webContents.postMessage(DESKTOP_PORT_CHANNEL, undefined, [peer.port2]),
+        );
+      }),
   };
 }

--- a/apps/desktop/src/main/electron/renderer-lifecycle.test.ts
+++ b/apps/desktop/src/main/electron/renderer-lifecycle.test.ts
@@ -1,0 +1,161 @@
+import { Context, Effect, Logger } from "effect";
+import type { WebContents } from "electron";
+import { describe, expect, it } from "vitest";
+
+import { makeRendererLifecycle } from "./renderer-lifecycle";
+
+type Gate = {
+  readonly resolve: () => void;
+  readonly reject: (error: Error) => void;
+  readonly promise: Promise<void>;
+};
+
+function makeGate(): Gate {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { resolve, reject, promise };
+}
+
+// Each fake peer's detach promise is gated so tests control exactly when the
+// previous peer finishes cleaning up.
+function makeHarness() {
+  const events: string[] = [];
+  const gates: Gate[] = [];
+  let nextPeer = 0;
+
+  const connect = () =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        nextPeer += 1;
+        const id = nextPeer;
+        const gate = makeGate();
+        gates.push(gate);
+        events.push(`attach:${id}`);
+        return { id, gate };
+      }),
+      (peer) =>
+        Effect.promise(() => peer.gate.promise).pipe(
+          Effect.ensuring(Effect.sync(() => events.push(`detach:${peer.id}`))),
+        ),
+    ).pipe(Effect.asVoid);
+
+  return {
+    events,
+    gates,
+    connect,
+    lifecycle: Effect.runSync(makeRendererLifecycle(connect)),
+    webContents: {} as WebContents,
+  };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function makeRecordingLogger() {
+  const logged: unknown[] = [];
+  const context = Context.empty().pipe(
+    Context.add(
+      Logger.CurrentLoggers,
+      new Set([
+        Logger.make(({ message }) => {
+          logged.push(...(Array.isArray(message) ? message : [message]));
+        }),
+      ]),
+    ),
+  ) as Context.Context<never>;
+  return { logged, context };
+}
+
+describe("makeRendererLifecycle", () => {
+  it("attaches the replacement only after the previous peer's detach resolves", async () => {
+    const h = makeHarness();
+    await Effect.runPromise(h.lifecycle.replace(h.webContents));
+    expect(h.events).toEqual(["attach:1"]);
+
+    const second = Effect.runPromise(h.lifecycle.replace(h.webContents));
+    await settle();
+    expect(h.events).toEqual(["attach:1"]);
+
+    h.gates[0]?.resolve();
+    await second;
+    expect(h.events).toEqual(["attach:1", "detach:1", "attach:2"]);
+  });
+
+  it("does not complete shutdown before the active peer's cleanup resolves", async () => {
+    const h = makeHarness();
+    await Effect.runPromise(h.lifecycle.replace(h.webContents));
+
+    let shutdownDone = false;
+    const shutdown = Effect.runPromise(h.lifecycle.shutdown).then(() => {
+      shutdownDone = true;
+    });
+    await settle();
+    expect(shutdownDone).toBe(false);
+
+    h.gates[0]?.resolve();
+    await shutdown;
+    expect(h.events).toEqual(["attach:1", "detach:1"]);
+  });
+
+  it("refuses attachments after shutdown", async () => {
+    const h = makeHarness();
+    await Effect.runPromise(h.lifecycle.shutdown);
+    await Effect.runPromise(h.lifecycle.replace(h.webContents));
+    expect(h.events).toEqual([]);
+  });
+
+  it("cleans up exactly once when close and shutdown race", async () => {
+    const h = makeHarness();
+    await Effect.runPromise(h.lifecycle.replace(h.webContents));
+
+    const racing = Promise.all([
+      Effect.runPromise(h.lifecycle.detach),
+      Effect.runPromise(h.lifecycle.shutdown),
+      Effect.runPromise(h.lifecycle.detach),
+    ]);
+    await settle();
+    h.gates[0]?.resolve();
+    await racing;
+    expect(h.events).toEqual(["attach:1", "detach:1"]);
+  });
+
+  it("logs a failed detach instead of leaking the rejection", async () => {
+    const h = makeHarness();
+    const { logged, context } = makeRecordingLogger();
+    await Effect.runPromise(h.lifecycle.replace(h.webContents));
+
+    const shutdown = Effect.runPromise(h.lifecycle.shutdown.pipe(Effect.provideContext(context)));
+    h.gates[0]?.reject(new Error("detach exploded"));
+    await shutdown;
+
+    expect(h.events).toEqual(["attach:1", "detach:1"]);
+    expect(logged).toContain("Failed to detach the renderer RPC peer");
+  });
+
+  it("releases the acquired peer and logs when connecting fails after acquisition", async () => {
+    const h = makeHarness();
+    const { logged, context } = makeRecordingLogger();
+    const lifecycle = Effect.runSync(
+      makeRendererLifecycle(() =>
+        h.connect().pipe(Effect.andThen(Effect.fail(new Error("handoff failed")))),
+      ),
+    );
+
+    const replace = Effect.runPromise(
+      lifecycle.replace(h.webContents).pipe(Effect.provideContext(context)),
+    );
+    await settle();
+    h.gates[0]?.resolve();
+    await replace;
+
+    expect(h.events).toEqual(["attach:1", "detach:1"]);
+    expect(logged).toContain("Failed to connect the renderer RPC peer");
+  });
+});

--- a/apps/desktop/src/main/electron/renderer-lifecycle.ts
+++ b/apps/desktop/src/main/electron/renderer-lifecycle.ts
@@ -1,0 +1,75 @@
+import { Cause, Effect, Exit, Scope, Semaphore } from "effect";
+import type { WebContents } from "electron";
+
+export type ConnectRenderer = (
+  webContents: WebContents,
+) => Effect.Effect<void, unknown, Scope.Scope>;
+
+export interface RendererLifecycle {
+  /** Detach the current peer (awaiting its cleanup), then attach a new one. */
+  readonly replace: (webContents: WebContents) => Effect.Effect<void>;
+  /** Detach the current peer and await its cleanup. */
+  readonly detach: Effect.Effect<void>;
+  /** Detach the current peer and refuse any later attachment. */
+  readonly shutdown: Effect.Effect<void>;
+}
+
+// Every transition holds the same permit, so reload, window close, and
+// runtime disposal can never clean up the same peer concurrently, and a
+// replacement peer is never attached before the previous peer's detach
+// resolves. Each attached peer owns a child Scope; closing it awaits the
+// peer's finalizers, including the oRPC detach promise.
+export function makeRendererLifecycle(connect: ConnectRenderer): Effect.Effect<RendererLifecycle> {
+  return Effect.gen(function* () {
+    const transitions = yield* Semaphore.make(1);
+    let current: Scope.Closeable | undefined;
+    let shutDown = false;
+
+    const close = (scope: Scope.Closeable) =>
+      Scope.close(scope, Exit.void).pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.void
+            : Effect.logError("Failed to detach the renderer RPC peer", cause),
+        ),
+      );
+
+    const detachCurrent = Effect.suspend(() => {
+      const scope = current;
+      current = undefined;
+      return scope ? close(scope) : Effect.void;
+    });
+
+    const attach = (webContents: WebContents) =>
+      Effect.gen(function* () {
+        const scope = yield* Scope.make();
+        const attached = yield* connect(webContents).pipe(Scope.provide(scope), Effect.exit);
+        if (Exit.isSuccess(attached)) {
+          current = scope;
+          return;
+        }
+        yield* close(scope);
+        if (!Cause.hasInterruptsOnly(attached.cause)) {
+          yield* Effect.logError("Failed to connect the renderer RPC peer", attached.cause);
+        }
+      });
+
+    return {
+      replace: (webContents) =>
+        transitions.withPermit(
+          Effect.gen(function* () {
+            yield* detachCurrent;
+            if (shutDown) return;
+            yield* attach(webContents);
+          }),
+        ),
+      detach: transitions.withPermit(detachCurrent),
+      shutdown: transitions.withPermit(
+        Effect.suspend(() => {
+          shutDown = true;
+          return detachCurrent;
+        }),
+      ),
+    } satisfies RendererLifecycle;
+  });
+}


### PR DESCRIPTION
## Problem

When the desktop renderer reloads, the window closes, or the app quits, cleanup of the current MessagePort RPC peer was started asynchronously but never awaited (`void disconnect()` in `main-window.ts`, `Effect.sync` finalizer). A replacement peer could attach while the previous one was still detaching, runtime disposal could complete before peer cleanup, and a rejected detach became an unhandled promise rejection.

## Solution

Follows the recommended shape in the issue: the renderer connection is now an Effect-owned scoped resource.

- `RendererChannel.connect` is an Effect acquisition whose release awaits the oRPC detach promise through `Effect.promise` before closing the port. A failed port handoff fails the acquisition scope, which runs the same release.
- New `renderer-lifecycle.ts` gives each renderer document a child `Scope` and serializes every transition (`replace`, `detach`, `shutdown`) behind a semaphore, so `did-finish-load`, window close, and application disposal can never clean up the same peer concurrently, and a replacement is only attached after the previous peer's finalizers resolve.
- `MainWindow` retains only the lifecycle; its scope finalizer runs `shutdown`, which awaits active peer cleanup and refuses late attachments, before destroying the window — so `ManagedRuntime.dispose()` waits for peer teardown.
- Unexpected detach/connect failures are logged via `Effect.logError`; interrupt-only causes stay silent, and renderer cancellation keeps running stream finalizers without being reported as an RPC failure (existing `desktop-rpc-server` behavior, unchanged).

## Tests

`renderer-lifecycle.test.ts` gates each fake peer's detach promise and proves:

- a replacement attaches only after the previous detach resolves
- shutdown does not complete before active peer cleanup resolves
- attachments are refused after shutdown
- cleanup runs exactly once when close and shutdown race
- a rejected detach is logged, not leaked
- a failed connect after acquisition releases the peer and is logged

`turbo run test typecheck --filter=desktop` (49 tests), `pnpm lint:check`, `pnpm format:check` all pass.

Fixes #154