### PR TITLE
fix(app): preserve pending prompts across server restarts

### DIFF
--- a/apps/app/src/features/chat/runtime/chat-subscription.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-subscription.test.ts
@@ -90,6 +90,24 @@ describe("RecoveringSubscription", () => {
     subscription.stop();
   });
 
+  it("keeps retrying repeated attach failures until it is stopped", async () => {
+    let opens = 0;
+    const subscription = new RecoveringSubscription({
+      subscribe: async () => {
+        opens += 1;
+        if (opens < 25) throw new DOMException("socket unavailable", "AbortError");
+        return hangingIterable();
+      },
+      getSnapshot: async () => snapshot,
+      onEvent: () => undefined,
+      retryDelayMs: () => 0,
+    });
+    subscription.start();
+
+    await expect.poll(() => opens).toBe(25);
+    subscription.stop();
+  });
+
   it("stops for good on session_closed and surfaces it exactly once", async () => {
     let opens = 0;
     const events: string[] = [];

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -38,6 +38,9 @@ class FakeTransport implements ChatSessionTransport {
   getMessagesCalls = 0;
   promptCalls: Array<{ messageId: string; parts: ReadonlyArray<PromptPart> }> = [];
   promptError: unknown = null;
+  // When set, prompt blocks on it — models a call waiting for the WebSocket
+  // reconnect loop to reach the restarted server.
+  promptGate: Promise<void> | null = null;
   responded: Array<{ requestId: string; response: AgentResponse }> = [];
 
   subscribe(onEvent: (event: ChatTransportEvent) => void): () => void {
@@ -48,13 +51,16 @@ class FakeTransport implements ChatSessionTransport {
   }
   prompt = async (input: { messageId: string; parts: ReadonlyArray<PromptPart> }) => {
     this.promptCalls.push(input);
+    if (this.promptGate) await this.promptGate;
     if (this.promptError) throw this.promptError;
     return { turnId: "turn-receipt" };
   };
   getMessages = async () => {
     this.getMessagesCalls += 1;
-    if (this.historyGate) await this.historyGate;
-    return this.history;
+    const history = this.history;
+    const gate = this.historyGate;
+    if (gate) await gate;
+    return history;
   };
   respondToAgentRequest = async (requestId: string, response: AgentResponse) => {
     this.responded.push({ requestId, response });
@@ -151,6 +157,121 @@ describe("Chat hydration", () => {
     const last = chat.store.getState().messages.at(-1)!;
     expect(last.role).toBe("assistant");
     expect(assistantText(last)).toBe("after the restart");
+  });
+
+  it("keeps a pending prompt across a restarted server snapshot", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.history = [userMessage("user-1", "hello")];
+    await attach({ cursor: 8 });
+
+    let releasePrompt: () => void = () => undefined;
+    transport.promptGate = new Promise((resolve) => {
+      releasePrompt = resolve;
+    });
+    const sent = chat.prompt("still queued");
+    await settle();
+
+    // The rebuilt server starts at cursor zero and has not accepted the prompt
+    // yet, so neither its idle phase nor its settled history may erase the
+    // optimistic bubble.
+    await attach({ cursor: 0 });
+    expect(chat.store.getState().messages.map((message) => message.role)).toEqual(["user", "user"]);
+    expect(chat.store.getState().status).toBe("submitted");
+
+    releasePrompt();
+    await sent;
+    // The cursor-zero snapshot predated acceptance, so settling the RPC must
+    // not briefly turn its stale idle phase into a ready composer.
+    expect(chat.store.getState().messages.map((message) => message.role)).toEqual(["user", "user"]);
+    expect(chat.store.getState().status).toBe("submitted");
+  });
+
+  it("applies a completed restart snapshot when the pending prompt settles", async () => {
+    const { chat, transport, attach } = makeChat();
+    const oldHistory = [userMessage("user-1", "hello")];
+    transport.history = oldHistory;
+    await attach({ cursor: 8 });
+
+    let releasePrompt: () => void = () => undefined;
+    transport.promptGate = new Promise((resolve) => {
+      releasePrompt = resolve;
+    });
+    const sent = chat.prompt("still queued");
+    await settle();
+    const { messageId } = transport.promptCalls[0]!;
+
+    // The restarted server has already accepted and completed the turn, but
+    // the unary prompt receipt is still pending on the recovering connection.
+    transport.history = [
+      ...oldHistory,
+      userMessage(messageId, "still queued"),
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "completed while reconnecting" }],
+      },
+    ];
+    await attach({
+      activePrompt: { messageId, parts: [{ type: "text", text: "still queued" }], seq: 1 },
+      activeTurn: activeTurn({ turnId: "turn-complete", chunks: [], complete: true }),
+      cursor: 6,
+    });
+    expect(chat.store.getState().status).toBe("submitted");
+
+    releasePrompt();
+    await sent;
+    await settle();
+
+    expect(chat.store.getState().messages.map((message) => message.id)).toEqual([
+      "user-1",
+      messageId,
+      "assistant-1",
+    ]);
+    expect(chat.store.getState().status).toBe("ready");
+  });
+
+  it("ignores a stale history read that overlapped a prompt", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    const oldHistory = [userMessage("user-1", "hello")];
+    transport.history = oldHistory;
+    await attach({ cursor: 8 });
+
+    let releaseStaleHistory: () => void = () => undefined;
+    transport.historyGate = new Promise((resolve) => {
+      releaseStaleHistory = resolve;
+    });
+    // Start a slow reconciliation before our prompt exists. Its response has
+    // already captured the old settled transcript.
+    live(9, { type: "session.turn.ended", turnId: "other", outcome: "canceled", phase: "idle" });
+    await settle();
+    expect(transport.getMessagesCalls).toBe(2);
+
+    await chat.prompt("new prompt");
+    const { messageId } = transport.promptCalls[0]!;
+
+    // A later attach obtains authoritative history and clears submitted. The
+    // older response must not overwrite this newer state when it finally lands.
+    transport.historyGate = null;
+    transport.history = [
+      ...oldHistory,
+      userMessage(messageId, "new prompt"),
+      { id: "assistant-1", role: "assistant", parts: [{ type: "text", text: "reply" }] },
+    ];
+    await attach({ cursor: 20 });
+    expect(chat.store.getState().messages.map((message) => message.id)).toEqual([
+      "user-1",
+      messageId,
+      "assistant-1",
+    ]);
+
+    releaseStaleHistory();
+    await settle();
+
+    expect(chat.store.getState().messages.map((message) => message.id)).toEqual([
+      "user-1",
+      messageId,
+      "assistant-1",
+    ]);
   });
 
   it("lays the history floor before folding buffered or live chunks", async () => {

--- a/apps/app/src/features/chat/runtime/chat.ts
+++ b/apps/app/src/features/chat/runtime/chat.ts
@@ -93,6 +93,17 @@ export class Chat {
   // internally and still complete, with the retried tail persisted but never
   // streamed — reconcile from history at turn end regardless of outcome.
   readonly #erroredTurnIds = new Set<string>();
+  // Prompts whose RPC has not settled. A call made after the socket drops can
+  // wait inside oRPC's reconnect loop until the restarted server is reachable;
+  // snapshots and settled history received meanwhile may not account for it.
+  readonly #promptsInFlight = new Set<string>();
+  // Invalidates a history read that overlaps a prompt, even when that prompt
+  // settles before the older read returns.
+  #promptRevision = 0;
+  // Latest snapshot phase held back while a prompt is invisible to that
+  // snapshot. Applied when the final successful prompt RPC settles, unless a
+  // newer lifecycle event has already supplied a phase.
+  #deferredSnapshotPhase: SessionPhase | null = null;
   #cursor = 0;
   #historyLoaded = false;
   // Non-null while the history floor is loading: live events queue here so
@@ -211,6 +222,7 @@ export class Chat {
       event.type !== "session.prompt.submitted" &&
       event.type !== "session.prompt.rejected"
     ) {
+      this.#deferredSnapshotPhase = null;
       this.#setStatus(statusFromPhase(event.phase));
     }
   }
@@ -392,7 +404,25 @@ export class Chat {
     if (this.#needsReconcile) void this.#reconcileHistory();
 
     this.#cursor = Math.max(this.#cursor, snapshot.cursor);
-    this.#setStatus(statusFromPhase(snapshot.status.phase));
+    // A prompt still waiting on the wire is invisible to this snapshot. Keep
+    // the sender-local submitted state, but retain the latest phase so a turn
+    // that completed before the unary receipt can converge when the RPC settles.
+    if (this.#promptsInFlight.size === 0) {
+      this.#deferredSnapshotPhase = null;
+      this.#setStatus(statusFromPhase(snapshot.status.phase));
+    } else {
+      const pendingPromptSnapshot = snapshot.activePrompt;
+      // `activePrompt` proves the server accepted our message. For idle, also
+      // require a later completed turn event: prompt.submitted itself keeps the
+      // previous complete turn beside the new prompt until its turn starts.
+      const accountsForPendingPrompt =
+        this.#promptsInFlight.size === 1 &&
+        pendingPromptSnapshot !== null &&
+        this.#promptsInFlight.has(pendingPromptSnapshot.messageId) &&
+        (snapshot.status.phase !== "idle" ||
+          (snapshot.activeTurn?.complete === true && snapshot.cursor > pendingPromptSnapshot.seq));
+      this.#deferredSnapshotPhase = accountsForPendingPrompt ? snapshot.status.phase : null;
+    }
   }
 
   #replayActiveTurn(activeTurn: NonNullable<SessionRuntimeSnapshot["activeTurn"]>): void {
@@ -468,8 +498,15 @@ export class Chat {
   // or streaming chunks must not be clobbered. A skipped reconcile converges
   // on the next reload instead.
   async #reconcileHistory(): Promise<void> {
+    // Settled history cannot contain a prompt that has not reached the server.
+    // Leave #needsReconcile set so a later turn boundary or attach retries it.
+    if (this.#promptsInFlight.size > 0) return;
+    const promptRevision = this.#promptRevision;
     try {
       const history = await this.#transport.getMessages();
+      // The read is stale if a prompt began while it was in flight — including
+      // the case where that prompt settled before this older response arrived.
+      if (promptRevision !== this.#promptRevision || this.#promptsInFlight.size > 0) return;
       // Same read as the floor's, so it answers the same question: a reconcile
       // that lands clears a floor read that failed earlier.
       this.#state.historyStatus = history === null ? "unavailable" : "settled";
@@ -532,6 +569,13 @@ export class Chat {
     if (this.#state.status !== status) this.#state.status = status;
   }
 
+  #resumeAfterPromptSettlement(): void {
+    const phase = this.#deferredSnapshotPhase;
+    this.#deferredSnapshotPhase = null;
+    if (phase !== null) this.#setStatus(statusFromPhase(phase));
+    if (this.#needsReconcile) void this.#reconcileHistory();
+  }
+
   // ---------------------------------------------------------------------
   // Public surface
   // ---------------------------------------------------------------------
@@ -541,6 +585,8 @@ export class Chat {
   prompt = async (text: string): Promise<void> => {
     const messageId = generateId();
     const parts: PromptPart[] = [{ type: "text", text }];
+    this.#promptRevision += 1;
+    this.#promptsInFlight.add(messageId);
     this.#state.error = undefined;
     this.#state.pushMessage(toUserMessage(messageId, parts));
     this.#setStatus("submitted");
@@ -549,8 +595,14 @@ export class Chat {
     } catch (promptError) {
       this.#state.error =
         promptError instanceof Error ? promptError : new Error(String(promptError));
+      this.#deferredSnapshotPhase = null;
       this.#setStatus("error");
       throw promptError;
+    } finally {
+      this.#promptsInFlight.delete(messageId);
+      if (this.#promptsInFlight.size === 0 && this.#state.status !== "error") {
+        this.#resumeAfterPromptSettlement();
+      }
     }
   };
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -43,19 +43,20 @@ export function createWsConnect(options: CreateVibestClientOptions): () => Promi
 
 /**
  * WebSocket client: every call multiplexed over one connection. The link takes
- * a lazy `connect` factory (oRPC 2.0.0-beta.16), so the socket is only opened
+ * a lazy `connect` factory (oRPC 2.0.0-beta.18), so the socket is only opened
  * on first use — and re-opened, with a fresh ticket, on every reconnect.
  */
 export function createVibestClient(options: CreateVibestClientOptions = {}): VibestClient {
   const link = new WebSocketRPCLink({
     connect: createWsConnect(options),
-    // Reconnect is opt-in in oRPC and OFF by default. Without it the link
-    // holds the dead socket after a drop and every later call hangs on a
-    // send into it — one network blip kills the client until a full page
-    // reload. Enabled, the next call after a drop re-invokes `connect` (and
-    // so mints a fresh ticket); in-flight calls still reject on the drop,
-    // which consumers (e.g. the chat transport's retry loop) recover from.
-    reconnect: { enabled: true },
+    // Reconnect is opt-in in oRPC and OFF by default. Without it one network
+    // blip kills the client until a full page reload. Enabled, calls made
+    // against a closed socket wait for `connect` (and a fresh ticket) until
+    // the server returns. Calls already sent still reject when that socket
+    // drops; consumers such as the chat subscription recover those at their
+    // own protocol boundary. Infinite retry is product behavior, so keep it
+    // explicit rather than relying on oRPC's current default.
+    reconnect: { enabled: true, maxAttempt: Infinity },
   });
   return createORPCClient(link);
 }


### PR DESCRIPTION
## Summary

- keep optimistic prompts visible while their RPC waits through a WebSocket reconnect
- reject settled-history responses that overlap a newer prompt, including responses that return after the prompt RPC settles
- resume deferred snapshot phase/history reconciliation when a completed prompt settles
- make the product requirement for infinite WebSocket reconnect attempts explicit
- cover repeated subscription recovery and the restart/history races with regression tests

## Root cause

After a server restart, the rebuilt session starts with a fresh cursor and an idle snapshot. A prompt queued on the disconnected WebSocket can still be pending when that snapshot and an older settled-history read arrive. Hydration then treats the server state as authoritative and replaces the sender-local optimistic message before the server has seen it.

The fix tracks pending prompt IDs, protects hydration and reconciliation while they are not represented by server state, and invalidates history reads that became stale across a prompt boundary.

## Verification

- `pnpm turbo run test typecheck --filter=@vibest/app --filter=@vibest/client --force`
  - app: 114 tests passed
  - client: 4 tests passed
- `pnpm check`
- real browser E2E with Vite, the API server, and the Pi harness:
  - `origin/main` reproduced the bug with a DOM mutation trace of `0 -> 1 -> 0` for the first prompt; the second prompt replied without a page reload
  - the fixed branch preserved the first prompt and received its reply after the API restarted
  - five additional fixed-branch restart races never observed the prompt count fall from `1` to `0`

## Relationship to existing work

Supersedes #230. In addition to its in-flight counter, this PR covers stale history reads that settle after the prompt and snapshots where the completed turn arrives before the unary prompt receipt.