### PR TITLE
fix(app): cancel chat runtime operations

### DIFF
--- a/apps/app/src/features/chat/runtime/chat-outgoing.ts
+++ b/apps/app/src/features/chat/runtime/chat-outgoing.ts
@@ -107,6 +107,11 @@ function maybeDispatchFollowUp(state: ChatDraft, effects: ChatEffects): void {
     return;
   }
   const next = state.outgoing[nextIndex]!;
+  const reconcile = state.sync.reconcile;
+  if (reconcile) {
+    state.sync.reconcile = null;
+    effects.push({ type: "cancelHistory", id: reconcile.id });
+  }
   state.outgoing[nextIndex] = { ...next, status: "sending" };
   if (!state.session.messages.some((message) => message.id === next.message.id)) {
     state.session.messages.push(next.message);

--- a/apps/app/src/features/chat/runtime/chat-runtime-types.ts
+++ b/apps/app/src/features/chat/runtime/chat-runtime-types.ts
@@ -53,6 +53,7 @@ export type ChatInput =
 
 export type ChatEffect =
   | { readonly type: "readHistory"; readonly id: number; readonly purpose: "floor" | "reconcile" }
+  | { readonly type: "cancelHistory"; readonly id: number }
   | {
       readonly type: "submitPrompt";
       readonly messageId: string;
@@ -81,6 +82,7 @@ export type ChatEffect =
   | { readonly type: "resolvePrompt"; readonly messageId: string }
   | { readonly type: "rejectPrompt"; readonly messageId: string; readonly error: Error }
   | { readonly type: "settleResponse"; readonly operationId: string }
+  | { readonly type: "abortLifetime" }
   | { readonly type: "unsubscribe" }
   | { readonly type: "notifyTerminated" }
   | { readonly type: "logError"; readonly message: string; readonly error: unknown };

--- a/apps/app/src/features/chat/runtime/chat-runtime.ts
+++ b/apps/app/src/features/chat/runtime/chat-runtime.ts
@@ -24,6 +24,26 @@ type FoldResource = {
   closed: boolean;
 };
 
+const raceWithSignal = <T>(operation: Promise<T>, signal: AbortSignal): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const abort = () => {
+      signal.removeEventListener("abort", abort);
+      reject(signal.reason);
+    };
+    if (signal.aborted) abort();
+    else signal.addEventListener("abort", abort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+
 export interface ChatRuntimeInit {
   readonly sessionRef: SessionRef;
   readonly transport: ChatSessionTransport;
@@ -37,6 +57,8 @@ export class ChatRuntime {
   readonly #transport: ChatSessionTransport;
   readonly #onTerminated: (() => void) | undefined;
   readonly #inputs: ChatInput[] = [];
+  readonly #lifetimeController = new AbortController();
+  readonly #historyControllers = new Map<number, AbortController>();
   readonly #promptPromises = new Map<string, PromptPromise>();
   readonly #responsePromises = new Map<string, () => void>();
   readonly #folds = new Map<string, FoldResource>();
@@ -77,22 +99,19 @@ export class ChatRuntime {
   #runEffect(effect: ChatEffect): void {
     switch (effect.type) {
       case "readHistory":
-        void this.#transport.getMessages().then(
-          (history) => {
-            this.#send({
-              type: "historyCompleted",
-              id: effect.id,
-              purpose: effect.purpose,
-              history,
-            });
-          },
-          (error: unknown) => {
-            this.#send({ type: "historyCompleted", id: effect.id, purpose: effect.purpose, error });
-          },
-        );
+        this.#readHistory(effect.id, effect.purpose);
+        break;
+      case "cancelHistory":
+        this.#historyControllers.get(effect.id)?.abort();
         break;
       case "submitPrompt":
-        void this.#transport.prompt({ messageId: effect.messageId, parts: effect.parts }).then(
+        void raceWithSignal(
+          this.#transport.prompt(
+            { messageId: effect.messageId, parts: effect.parts },
+            { signal: this.#lifetimeController.signal },
+          ),
+          this.#lifetimeController.signal,
+        ).then(
           () =>
             this.#send({
               type: "outgoingCompleted",
@@ -109,31 +128,44 @@ export class ChatRuntime {
         );
         break;
       case "submitSteer":
-        void this.#transport
-          .steer({
-            expectedTurnId: effect.expectedTurnId,
-            messageId: effect.messageId,
-            parts: effect.parts,
-          })
-          .then(
-            () =>
-              this.#send({
-                type: "outgoingCompleted",
-                messageId: effect.messageId,
-                delivery: "steer",
-              }),
-            (error: unknown) =>
-              this.#send({
-                type: "outgoingCompleted",
-                messageId: effect.messageId,
-                delivery: "steer",
-                error: error instanceof Error ? error : new Error(String(error)),
-              }),
-          );
+        void raceWithSignal(
+          this.#transport.steer(
+            {
+              expectedTurnId: effect.expectedTurnId,
+              messageId: effect.messageId,
+              parts: effect.parts,
+            },
+            { signal: this.#lifetimeController.signal },
+          ),
+          this.#lifetimeController.signal,
+        ).then(
+          () =>
+            this.#send({
+              type: "outgoingCompleted",
+              messageId: effect.messageId,
+              delivery: "steer",
+            }),
+          (error: unknown) =>
+            this.#send({
+              type: "outgoingCompleted",
+              messageId: effect.messageId,
+              delivery: "steer",
+              error: error instanceof Error ? error : new Error(String(error)),
+            }),
+        );
         break;
       case "respondToRequest":
-        void this.#transport.respondToAgentRequest(effect.requestId, effect.response).then(
-          () => this.#send({ type: "requestResponseCompleted", operationId: effect.operationId }),
+        void raceWithSignal(
+          this.#transport.respondToAgentRequest(effect.requestId, effect.response, {
+            signal: this.#lifetimeController.signal,
+          }),
+          this.#lifetimeController.signal,
+        ).then(
+          () =>
+            this.#send({
+              type: "requestResponseCompleted",
+              operationId: effect.operationId,
+            }),
           (error: unknown) =>
             this.#send({
               type: "requestResponseCompleted",
@@ -176,6 +208,9 @@ export class ChatRuntime {
         resolve?.();
         break;
       }
+      case "abortLifetime":
+        this.#lifetimeController.abort();
+        break;
       case "unsubscribe":
         this.#unsubscribeRequested = true;
         this.#unsubscribe?.();
@@ -188,6 +223,33 @@ export class ChatRuntime {
         console.error(effect.message, effect.error);
         break;
     }
+  }
+
+  #readHistory(id: number, purpose: "floor" | "reconcile"): void {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    this.#historyControllers.set(id, controller);
+    if (this.#lifetimeController.signal.aborted) abort();
+    else this.#lifetimeController.signal.addEventListener("abort", abort, { once: true });
+
+    void raceWithSignal(
+      this.#transport.getMessages({ signal: controller.signal }),
+      controller.signal,
+    )
+      .then(
+        (history) => {
+          this.#send({ type: "historyCompleted", id, purpose, history });
+        },
+        (error: unknown) => {
+          this.#send({ type: "historyCompleted", id, purpose, error });
+        },
+      )
+      .finally(() => {
+        this.#lifetimeController.signal.removeEventListener("abort", abort);
+        if (this.#historyControllers.get(id) === controller) {
+          this.#historyControllers.delete(id);
+        }
+      });
   }
 
   #foldKey(turnId: string, generation: number): string {
@@ -245,15 +307,18 @@ export class ChatRuntime {
   }
 
   setModel(providerId: string, modelId: string): Promise<void> {
-    return this.#transport.setModel(providerId, modelId);
+    const signal = this.#lifetimeController.signal;
+    return raceWithSignal(this.#transport.setModel(providerId, modelId, { signal }), signal);
   }
 
   setReasoningEffort(reasoningEffort: ReasoningEffort): Promise<void> {
-    return this.#transport.setReasoningEffort(reasoningEffort);
+    const signal = this.#lifetimeController.signal;
+    return raceWithSignal(this.#transport.setReasoningEffort(reasoningEffort, { signal }), signal);
   }
 
   setPermissionMode(mode: PermissionMode): Promise<void> {
-    return this.#transport.setPermissionMode(mode);
+    const signal = this.#lifetimeController.signal;
+    return raceWithSignal(this.#transport.setPermissionMode(mode, { signal }), signal);
   }
 
   respondToAgentRequest(requestId: string, response: AgentResponse): Promise<void> {

--- a/apps/app/src/features/chat/runtime/chat-session.ts
+++ b/apps/app/src/features/chat/runtime/chat-session.ts
@@ -302,6 +302,10 @@ function terminate(
     });
   }
   state.outgoing = [];
+  for (const operationId of Object.keys(state.pendingResponses)) {
+    effects.push({ type: "settleResponse", operationId });
+  }
+  state.pendingResponses = {};
   state.lifecycle.session = "terminated";
   state.session.activeTurnId = null;
   state.session.pendingRequests = [];
@@ -310,7 +314,7 @@ function terminate(
   state.session.error = new Error(
     reason === "session_deleted" ? "Session deleted" : "Session closed",
   );
-  effects.push({ type: "unsubscribe" }, { type: "notifyTerminated" });
+  effects.push({ type: "abortLifetime" }, { type: "unsubscribe" }, { type: "notifyTerminated" });
 }
 
 export function handleTransportEvent(
@@ -324,8 +328,10 @@ export function handleTransportEvent(
   }
   if (!isChatActive(state)) return;
   if (event.type === "attached") {
-    if (state.sync.reconcile && state.sync.reconcile.promptRevision !== state.prompt.revision) {
+    const reconcile = state.sync.reconcile;
+    if (reconcile) {
       state.sync.reconcile = null;
+      effects.push({ type: "cancelHistory", id: reconcile.id });
     }
     if (!state.sync.historyLoaded) {
       startHistoryFloor(state, effects, event.snapshot);

--- a/apps/app/src/features/chat/runtime/chat-transport-port.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport-port.ts
@@ -46,6 +46,10 @@ export type ChatTransportEvent =
   | { readonly type: "closed"; readonly reason: "session_closed" | "session_deleted" }
   | SessionScopedEvent;
 
+export type ChatTransportCallOptions = {
+  readonly signal?: AbortSignal;
+};
+
 export interface ChatSessionTransport {
   /**
    * Persistent subscription (call-to-dispose). Emits "attached" (subscription
@@ -60,35 +64,48 @@ export interface ChatSessionTransport {
    * subscription like everyone else's. `messageId` is the optimistic user
    * message's id; the server echoes it on `session.prompt.submitted` (dedupe).
    */
-  prompt(input: {
-    readonly messageId: string;
-    readonly parts: ReadonlyArray<PromptPart>;
-  }): Promise<{ readonly turnId: string }>;
-  steer(input: {
-    readonly expectedTurnId: string;
-    readonly messageId: string;
-    readonly parts: ReadonlyArray<PromptPart>;
-  }): Promise<void>;
+  prompt(
+    input: {
+      readonly messageId: string;
+      readonly parts: ReadonlyArray<PromptPart>;
+    },
+    options?: ChatTransportCallOptions,
+  ): Promise<{ readonly turnId: string }>;
+  steer(
+    input: {
+      readonly expectedTurnId: string;
+      readonly messageId: string;
+      readonly parts: ReadonlyArray<PromptPart>;
+    },
+    options?: ChatTransportCallOptions,
+  ): Promise<void>;
   /**
    * The session's native history as final-form UIMessages, or `null` when this
    * harness serves no history — capability absence is a normal outcome here,
    * not an error. All three harnesses serve history today, so `null` is the
    * degraded path, not the common one.
    */
-  getMessages(): Promise<readonly UIMessage[] | null>;
+  getMessages(options?: ChatTransportCallOptions): Promise<readonly UIMessage[] | null>;
   /**
    * Resolves normally when the request is no longer pending — including when
    * another client answered it first (the server's "not pending" is an
    * outcome, not a failure, from the responder's point of view).
    */
-  respondToAgentRequest(requestId: string, response: AgentResponse): Promise<void>;
+  respondToAgentRequest(
+    requestId: string,
+    response: AgentResponse,
+    options?: ChatTransportCallOptions,
+  ): Promise<void>;
   // Session-scoped config setters — separate session calls, never bundled into
   // a prompt turn. The transport already knows its SessionRef. The model is
   // the flat providerId/modelId pair — always together, modelId alone is only
   // unique within its provider.
-  setModel(providerId: string, modelId: string): Promise<void>;
-  setReasoningEffort(reasoningEffort: ReasoningEffort): Promise<void>;
-  setPermissionMode(mode: PermissionMode): Promise<void>;
+  setModel(providerId: string, modelId: string, options?: ChatTransportCallOptions): Promise<void>;
+  setReasoningEffort(
+    reasoningEffort: ReasoningEffort,
+    options?: ChatTransportCallOptions,
+  ): Promise<void>;
+  setPermissionMode(mode: PermissionMode, options?: ChatTransportCallOptions): Promise<void>;
 }
 
 // Binds a SessionRef to a transport. ChatManager holds one of these instead of

--- a/apps/app/src/features/chat/runtime/chat-transport.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport.test.ts
@@ -259,6 +259,64 @@ describe("OrpcChatSessionTransport subscription", () => {
 });
 
 describe("OrpcChatSessionTransport RPC mapping", () => {
+  it("forwards abort signals as the oRPC call options", async () => {
+    const calls: Array<{ name: string; options: unknown }> = [];
+    const record = (name: string, options: unknown) => calls.push({ name, options });
+    const client = {
+      session: {
+        ...baseSession,
+        prompt: async (_input: unknown, options?: unknown) => {
+          record("prompt", options);
+          return { turnId: "turn-1" };
+        },
+        getMessages: async (_input: unknown, options?: unknown) => {
+          record("getMessages", options);
+          return { messages: [] };
+        },
+        respondToAgentRequest: async (_input: unknown, options?: unknown) => {
+          record("respondToAgentRequest", options);
+        },
+        setModel: async (_input: unknown, options?: unknown) => {
+          record("setModel", options);
+        },
+        setReasoningEffort: async (_input: unknown, options?: unknown) => {
+          record("setReasoningEffort", options);
+        },
+        setPermissionMode: async (_input: unknown, options?: unknown) => {
+          record("setPermissionMode", options);
+        },
+      },
+    } satisfies ChatTransportClient;
+    const transport = new OrpcChatSessionTransport(client, ref);
+    const signal = new AbortController().signal;
+
+    await transport.prompt(
+      { messageId: "message-1", parts: [{ type: "text", text: "hi" }] },
+      { signal },
+    );
+    await transport.getMessages({ signal });
+    await transport.respondToAgentRequest(
+      "request-1",
+      { type: "tool", behavior: "allow" },
+      { signal },
+    );
+    await transport.setModel("provider", "model", { signal });
+    await transport.setReasoningEffort("high", { signal });
+    await transport.setPermissionMode("ask", { signal });
+
+    expect(calls.map((call) => call.name)).toEqual([
+      "prompt",
+      "getMessages",
+      "respondToAgentRequest",
+      "setModel",
+      "setReasoningEffort",
+      "setPermissionMode",
+    ]);
+    expect(calls.map((call) => call.options)).toEqual(
+      Array.from({ length: 6 }, () => ({ signal })),
+    );
+  });
+
   it("maps UNSUPPORTED history to null (capability absence, not failure)", async () => {
     const client = {
       session: {

--- a/apps/app/src/features/chat/runtime/chat-transport.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport.ts
@@ -13,7 +13,11 @@ import { exponentialBackoffMs } from "@/lib/utils";
 
 import type { AgentResponse } from "./agent-requests";
 import { RecoveringSubscription } from "./chat-subscription";
-import type { ChatSessionTransport, ChatTransportEvent } from "./chat-transport-port";
+import type {
+  ChatSessionTransport,
+  ChatTransportCallOptions,
+  ChatTransportEvent,
+} from "./chat-transport-port";
 
 // Backoff between subscription recoveries: 500ms doubling to a 10s ceiling,
 // reset by every successful attach.
@@ -73,28 +77,39 @@ export class OrpcChatSessionTransport implements ChatSessionTransport {
     return () => subscription.stop();
   }
 
-  prompt = async (input: {
-    readonly messageId: string;
-    readonly parts: ReadonlyArray<PromptPart>;
-  }): Promise<{ readonly turnId: string }> => {
-    return await this.client.session.prompt({
-      ref: this.#ref,
-      parts: input.parts,
-      messageId: input.messageId,
-    });
+  prompt = async (
+    input: {
+      readonly messageId: string;
+      readonly parts: ReadonlyArray<PromptPart>;
+    },
+    options?: ChatTransportCallOptions,
+  ): Promise<{ readonly turnId: string }> => {
+    return await this.client.session.prompt(
+      {
+        ref: this.#ref,
+        parts: input.parts,
+        messageId: input.messageId,
+      },
+      options,
+    );
   };
 
-  steer = async (input: {
-    readonly expectedTurnId: string;
-    readonly messageId: string;
-    readonly parts: ReadonlyArray<PromptPart>;
-  }): Promise<void> => {
-    await this.client.session.steer({ ref: this.#ref, ...input });
+  steer = async (
+    input: {
+      readonly expectedTurnId: string;
+      readonly messageId: string;
+      readonly parts: ReadonlyArray<PromptPart>;
+    },
+    options?: ChatTransportCallOptions,
+  ): Promise<void> => {
+    await this.client.session.steer({ ref: this.#ref, ...input }, options);
   };
 
-  getMessages = async (): Promise<readonly UIMessage[] | null> => {
+  getMessages = async (
+    options?: ChatTransportCallOptions,
+  ): Promise<readonly UIMessage[] | null> => {
     try {
-      const result = await this.client.session.getMessages({ ref: this.#ref });
+      const result = await this.client.session.getMessages({ ref: this.#ref }, options);
       return result.messages;
     } catch (error) {
       // Capability absence is a normal outcome, not a failure.
@@ -107,28 +122,45 @@ export class OrpcChatSessionTransport implements ChatSessionTransport {
   // clients on one session, that usually means another client answered first.
   // The outcome the responder wanted (request resolved) holds either way, so
   // it maps to success; the request.replied event closes the card everywhere.
-  respondToAgentRequest = async (requestId: string, response: AgentResponse): Promise<void> => {
+  respondToAgentRequest = async (
+    requestId: string,
+    response: AgentResponse,
+    options?: ChatTransportCallOptions,
+  ): Promise<void> => {
     try {
-      await this.client.session.respondToAgentRequest({
-        ref: this.#ref,
-        requestId,
-        response,
-      });
+      await this.client.session.respondToAgentRequest(
+        {
+          ref: this.#ref,
+          requestId,
+          response,
+        },
+        options,
+      );
     } catch (error) {
       if (error instanceof ORPCError && error.code === "NOT_FOUND") return;
       throw error;
     }
   };
 
-  setModel = async (providerId: string, modelId: string): Promise<void> => {
-    await this.client.session.setModel({ ref: this.#ref, providerId, modelId });
+  setModel = async (
+    providerId: string,
+    modelId: string,
+    options?: ChatTransportCallOptions,
+  ): Promise<void> => {
+    await this.client.session.setModel({ ref: this.#ref, providerId, modelId }, options);
   };
 
-  setReasoningEffort = async (reasoningEffort: ReasoningEffort): Promise<void> => {
-    await this.client.session.setReasoningEffort({ ref: this.#ref, reasoningEffort });
+  setReasoningEffort = async (
+    reasoningEffort: ReasoningEffort,
+    options?: ChatTransportCallOptions,
+  ): Promise<void> => {
+    await this.client.session.setReasoningEffort({ ref: this.#ref, reasoningEffort }, options);
   };
 
-  setPermissionMode = async (permissionMode: PermissionMode): Promise<void> => {
-    await this.client.session.setPermissionMode({ ref: this.#ref, permissionMode });
+  setPermissionMode = async (
+    permissionMode: PermissionMode,
+    options?: ChatTransportCallOptions,
+  ): Promise<void> => {
+    await this.client.session.setPermissionMode({ ref: this.#ref, permissionMode }, options);
   };
 }

--- a/apps/app/src/features/chat/runtime/chat-update.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 
 import { createChatState, type ChatState } from "./chat-state";
 import { type ChatInput, updateChat } from "./chat-update";
-import { deriveChatView } from "./chat-view";
 
 const ref = {
   projectId: "project-1",
@@ -413,7 +412,11 @@ describe("updateChat", () => {
     const prompting = createChatState();
     const pending = requested("sending", "in flight");
     prompting.outgoing = [{ message: pending.message, parts: pending.parts, status: "sending" }];
-    expectIgnored(prompting, { type: "promptCompleted", messageId: "late" });
+    expectIgnored(prompting, {
+      type: "outgoingCompleted",
+      messageId: "late",
+      delivery: "follow-up",
+    });
 
     const folding = createChatState();
     folding.turns.folds.active = { generation: 3, status: "open" };
@@ -463,20 +466,52 @@ describe("updateChat", () => {
     expect(transition.effects).toEqual([]);
   });
 
+  it("settles and removes pending responses on disposal", () => {
+    const state = createChatState();
+    state.pendingResponses["response-1"] = {
+      request: undefined,
+      restoreOnFailure: true,
+      response: { type: "tool", behavior: "allow" },
+    };
+
+    const transition = updateChat(state, { type: "dispose" });
+
+    expect(transition.state.pendingResponses).toEqual({});
+    expect(transition.effects).toContainEqual({
+      type: "settleResponse",
+      operationId: "response-1",
+    });
+    expect(
+      updateChat(transition.state, {
+        type: "requestResponseCompleted",
+        operationId: "response-1",
+      }),
+    ).toEqual({ state: transition.state, effects: [] });
+  });
+
   it("publishes the complete terminal shape in one transition and ignores later events", () => {
-    let transition = updateChat(createChatState(), requested("queued", "later"));
+    const state = createChatState();
+    state.pendingResponses["response-1"] = {
+      request: undefined,
+      restoreOnFailure: true,
+      response: { type: "tool", behavior: "allow" },
+    };
+    let transition = updateChat(state, requested("queued", "later"));
     transition = updateChat(transition.state, {
       type: "transportEvent",
       event: { type: "closed", reason: "session_deleted" },
     });
 
-    expect(deriveChatView(transition.state)).toMatchObject({
-      queuedMessages: [],
-      pendingRequests: [],
-      historyStatus: "settled",
-      status: "error",
-      error: new Error("Session deleted"),
+    expect(transition.state.pendingResponses).toEqual({});
+    expect(transition.effects).toContainEqual({
+      type: "settleResponse",
+      operationId: "response-1",
     });
+    expect(transition.state.outgoing).toEqual([]);
+    expect(transition.state.session.pendingRequests).toEqual([]);
+    expect(transition.state.session.historyStatus).toBe("settled");
+    expect(transition.state.session.status).toBe("error");
+    expect(transition.state.session.error).toEqual(new Error("Session deleted"));
     const terminal = transition.state;
     expect(
       updateChat(terminal, {

--- a/apps/app/src/features/chat/runtime/chat-update.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.ts
@@ -45,6 +45,7 @@ export function updateChat(state: ChatState, input: ChatInput): ChatTransition {
     const next = copyChatState(state);
     const effects: ChatEffects = [];
     next.lifecycle.instance = "disposed";
+    effects.push({ type: "abortLifetime" });
     for (const outgoing of next.outgoing) {
       effects.push({
         type: "rejectPrompt",
@@ -53,6 +54,10 @@ export function updateChat(state: ChatState, input: ChatInput): ChatTransition {
       });
     }
     next.outgoing = [];
+    for (const operationId of Object.keys(next.pendingResponses)) {
+      effects.push({ type: "settleResponse", operationId });
+    }
+    next.pendingResponses = {};
     for (const turnId of Object.keys(next.turns.folds)) abandonFold(next, effects, turnId);
     effects.push({ type: "unsubscribe" });
     return { state: next, effects };
@@ -100,7 +105,7 @@ export function updateChat(state: ChatState, input: ChatInput): ChatTransition {
     return { state, effects: [] };
   }
   if (
-    input.type === "promptCompleted" &&
+    input.type === "outgoingCompleted" &&
     !state.outgoing.some(
       (message) => message.message.id === input.messageId && message.status === "sending",
     )

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -14,7 +14,11 @@ import { describe, expect, it } from "vitest";
 
 import type { AgentResponse } from "./agent-requests";
 import { Chat } from "./chat";
-import type { ChatSessionTransport, ChatTransportEvent } from "./chat-transport-port";
+import type {
+  ChatSessionTransport,
+  ChatTransportCallOptions,
+  ChatTransportEvent,
+} from "./chat-transport-port";
 
 const ref = {
   projectId: "project-1",
@@ -36,12 +40,14 @@ class FakeTransport implements ChatSessionTransport {
   // floor against live traffic.
   historyGate: Promise<void> | null = null;
   getMessagesCalls = 0;
+  historySignals: AbortSignal[] = [];
   promptCalls: Array<{ messageId: string; parts: ReadonlyArray<PromptPart> }> = [];
   steerCalls: Array<{
     expectedTurnId: string;
     messageId: string;
     parts: ReadonlyArray<PromptPart>;
   }> = [];
+  promptSignals: AbortSignal[] = [];
   promptError: unknown = null;
   steerError: unknown = null;
   steerGates: Promise<void>[] = [];
@@ -50,6 +56,9 @@ class FakeTransport implements ChatSessionTransport {
   // reconnect loop to reach the restarted server.
   promptGate: Promise<void> | null = null;
   responded: Array<{ requestId: string; response: AgentResponse }> = [];
+  responseSignals: AbortSignal[] = [];
+  responseGate: Promise<void> | null = null;
+  configSignals: AbortSignal[] = [];
 
   subscribe(onEvent: (event: ChatTransportEvent) => void): () => void {
     this.onEvent = onEvent;
@@ -57,38 +66,63 @@ class FakeTransport implements ChatSessionTransport {
       this.disposed += 1;
     };
   }
-  prompt = async (input: { messageId: string; parts: ReadonlyArray<PromptPart> }) => {
+  prompt = async (
+    input: { messageId: string; parts: ReadonlyArray<PromptPart> },
+    options?: ChatTransportCallOptions,
+  ) => {
     this.promptCalls.push(input);
+    if (options?.signal) this.promptSignals.push(options.signal);
+    options?.signal?.throwIfAborted();
     const gate = this.promptGates.shift() ?? this.promptGate;
     const error = this.promptError;
     if (gate) await gate;
     if (error) throw error;
     return { turnId: "turn-receipt" };
   };
-  steer = async (input: {
-    expectedTurnId: string;
-    messageId: string;
-    parts: ReadonlyArray<PromptPart>;
-  }) => {
+  steer = async (
+    input: {
+      expectedTurnId: string;
+      messageId: string;
+      parts: ReadonlyArray<PromptPart>;
+    },
+    options?: ChatTransportCallOptions,
+  ) => {
     this.steerCalls.push(input);
+    if (options?.signal) options.signal.throwIfAborted();
     const gate = this.steerGates.shift();
     if (gate) await gate;
     if (this.steerError) throw this.steerError;
   };
 
-  getMessages = async () => {
+  getMessages = async (options?: ChatTransportCallOptions) => {
     this.getMessagesCalls += 1;
+    if (options?.signal) this.historySignals.push(options.signal);
+    options?.signal?.throwIfAborted();
     const history = this.history;
     const gate = this.historyGate;
     if (gate) await gate;
     return history;
   };
-  respondToAgentRequest = async (requestId: string, response: AgentResponse) => {
+  respondToAgentRequest = async (
+    requestId: string,
+    response: AgentResponse,
+    options?: ChatTransportCallOptions,
+  ) => {
     this.responded.push({ requestId, response });
+    if (options?.signal) this.responseSignals.push(options.signal);
+    options?.signal?.throwIfAborted();
+    const gate = this.responseGate;
+    if (gate) await gate;
   };
-  setModel = async (_providerId: string, _modelId: string) => {};
-  setReasoningEffort = async (_effort: ReasoningEffort) => {};
-  setPermissionMode = async (_mode: PermissionMode) => {};
+  setModel = async (_providerId: string, _modelId: string, options?: ChatTransportCallOptions) => {
+    if (options?.signal) this.configSignals.push(options.signal);
+  };
+  setReasoningEffort = async (_effort: ReasoningEffort, options?: ChatTransportCallOptions) => {
+    if (options?.signal) this.configSignals.push(options.signal);
+  };
+  setPermissionMode = async (_mode: PermissionMode, options?: ChatTransportCallOptions) => {
+    if (options?.signal) this.configSignals.push(options.signal);
+  };
 }
 
 const makeChat = (options?: { onTerminated?: () => void }) => {
@@ -1899,6 +1933,52 @@ describe("Chat history reconcile", () => {
     ]);
   });
 
+  it("aborts a stale reconcile when a prompt starts without retrying the prompt", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    await attach({});
+    let releaseHistory: () => void = () => undefined;
+    transport.historyGate = new Promise((resolve) => {
+      releaseHistory = resolve;
+    });
+    live(1, { type: "session.turn.started", turnId: "turn-1", phase: "running" });
+    live(2, { type: "session.turn.ended", turnId: "turn-1", outcome: "failed", phase: "idle" });
+    await settle();
+
+    const staleSignal = transport.historySignals[1]!;
+    const prompted = chat.prompt("new turn");
+    await prompted;
+
+    expect(staleSignal.aborted).toBe(true);
+    expect(transport.promptCalls).toHaveLength(1);
+    expect(transport.promptSignals[0]?.aborted).toBe(false);
+
+    releaseHistory();
+    await settle();
+    expect(transport.promptCalls).toHaveLength(1);
+  });
+
+  it("aborts a reconcile invalidated by a newer authoritative snapshot", async () => {
+    const { transport, attach, live } = makeChat();
+    await attach({});
+    let releaseHistory: () => void = () => undefined;
+    transport.historyGate = new Promise((resolve) => {
+      releaseHistory = resolve;
+    });
+    live(1, { type: "session.turn.started", turnId: "turn-1", phase: "running" });
+    live(2, { type: "session.turn.ended", turnId: "turn-1", outcome: "failed", phase: "idle" });
+    await settle();
+
+    const staleSignal = transport.historySignals[1]!;
+    await attach({ cursor: 2 });
+
+    expect(staleSignal.aborted).toBe(true);
+    expect(transport.historySignals[2]).not.toBe(staleSignal);
+    expect(transport.historySignals[2]?.aborted).toBe(false);
+
+    releaseHistory();
+    await settle();
+  });
+
   it("skips the reconcile while a newer turn is already streaming", async () => {
     const { chat, transport, attach, live } = makeChat();
     await attach({});
@@ -2185,11 +2265,47 @@ describe("Chat lifecycle", () => {
 
     emit({ type: "closed", reason: "session_deleted" });
 
+    expect(transport.promptSignals[0]?.aborted).toBe(true);
     await expect(submitting).rejects.toThrow("Session is no longer available");
     releasePrompt();
     await settle();
     expect(chat.store.getState().session.error?.message).toBe("Session deleted");
   });
+
+  it.each(["disposal", "termination"] as const)(
+    "aborts history and response work on %s",
+    async (lifecycle) => {
+      const { chat, transport, emit, attach } = makeChat();
+      let releaseHistory: () => void = () => undefined;
+      transport.historyGate = new Promise((resolve) => {
+        releaseHistory = resolve;
+      });
+      await attach({});
+      let releaseResponse: () => void = () => undefined;
+      transport.responseGate = new Promise((resolve) => {
+        releaseResponse = resolve;
+      });
+      const response = chat.respondToAgentRequest("request-1", {
+        type: "tool",
+        behavior: "allow",
+      });
+      await settle();
+
+      if (lifecycle === "disposal") chat.dispose();
+      else emit({ type: "closed", reason: "session_deleted" });
+
+      expect(transport.historySignals[0]?.aborted).toBe(true);
+      expect(transport.responseSignals[0]?.aborted).toBe(true);
+      await response;
+      await settle();
+      releaseHistory();
+      releaseResponse();
+      await settle();
+      expect(chat.store.getState().session.error?.message).toBe(
+        lifecycle === "termination" ? "Session deleted" : undefined,
+      );
+    },
+  );
 
   it("rejects queued prompts when the session terminates", async () => {
     const { chat, emit, attach } = makeChat();
@@ -2224,11 +2340,25 @@ describe("Chat lifecycle", () => {
 
     chat.dispose();
 
+    expect(transport.promptSignals[0]?.aborted).toBe(true);
     await expect(submitting).rejects.toThrow("Chat disposed");
     await expect(waiting).rejects.toThrow("Chat disposed");
     releasePrompt();
     await settle();
     expect(transport.promptCalls).toHaveLength(1);
     expect(transport.disposed).toBe(1);
+  });
+
+  it("passes an already-aborted lifetime signal to config setters after disposal", async () => {
+    const { chat, transport } = makeChat();
+    chat.dispose();
+
+    await expect(chat.setModel("provider", "model")).rejects.toMatchObject({ name: "AbortError" });
+    await expect(chat.setReasoningEffort("high")).rejects.toMatchObject({ name: "AbortError" });
+    await expect(chat.setPermissionMode("ask")).rejects.toMatchObject({ name: "AbortError" });
+
+    expect(transport.configSignals).toHaveLength(3);
+    expect(transport.configSignals.every((signal) => signal.aborted)).toBe(true);
+    expect(new Set(transport.configSignals).size).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- forward optional `AbortSignal`s through every Chat-owned unary transport call
- abort all in-flight and future Chat work on disposal or terminal session closure
- cancel stale reconciliation reads when a prompt or newer authoritative snapshot supersedes them
- race runtime operations against their signals so uncooperative transports cannot leave runtime promises or controller entries pending
- explicitly settle pending request-response callers during teardown
- keep prompt delivery ambiguity intact: cancellation never causes an automatic prompt retry

## Validation

- app: 13 files / 152 tests
- app typecheck
- lint with warnings denied
- format check
- `git diff --check`
- independent review: no significant findings

## Residual behavior

A transport that ignores its signal may continue its own underlying work, but it can no longer retain Chat runtime state, public response promises, history controller entries, or lifetime listeners.

## Stack

Depends on #247.
