### PR TITLE
fix(chat): track session stream generations

### DIFF
--- a/apps/app/src/features/chat/runtime/chat-session.ts
+++ b/apps/app/src/features/chat/runtime/chat-session.ts
@@ -47,10 +47,6 @@ export function hydrateSnapshot(
   skipGapCheck: boolean,
 ): void {
   if (!isChatActive(state)) return;
-  if (snapshot.cursor < state.sync.cursor) {
-    state.sync.cursor = 0;
-    state.sync.needsReconcile = true;
-  }
 
   state.session.pendingRequests = [];
   for (const request of snapshot.pendingRequests) addRequest(state, effects, request);
@@ -170,7 +166,13 @@ export function applyEvent(
   effects: ChatEffects,
   event: SessionScopedEvent,
 ): void {
-  if (!isChatActive(state) || event.seq <= state.sync.cursor) return;
+  if (
+    !isChatActive(state) ||
+    event.streamId !== state.sync.streamId ||
+    event.seq <= state.sync.cursor
+  ) {
+    return;
+  }
   state.sync.cursor = event.seq;
 
   switch (event.type) {
@@ -317,6 +319,23 @@ function terminate(
   effects.push({ type: "abortLifetime" }, { type: "unsubscribe" }, { type: "notifyTerminated" });
 }
 
+const attachStream = (
+  state: ChatDraft,
+  effects: ChatEffects,
+  snapshot: SessionRuntimeSnapshot,
+): boolean => {
+  const previousStreamId = state.sync.streamId;
+  state.sync.streamId = snapshot.streamId;
+  if (previousStreamId === null || previousStreamId === snapshot.streamId) return false;
+
+  for (const turnId of Object.keys(state.turns.folds)) abandonFold(state, effects, turnId);
+  state.turns.recoverTurnIds = [];
+  state.turns.erroredTurnIds = [];
+  state.sync.cursor = 0;
+  state.sync.needsReconcile = true;
+  return true;
+};
+
 export function handleTransportEvent(
   state: ChatDraft,
   effects: ChatEffects,
@@ -333,15 +352,21 @@ export function handleTransportEvent(
       state.sync.reconcile = null;
       effects.push({ type: "cancelHistory", id: reconcile.id });
     }
+    const changedStream = attachStream(state, effects, event.snapshot);
     if (!state.sync.historyLoaded) {
       startHistoryFloor(state, effects, event.snapshot);
     } else if (state.sync.floor) {
-      state.sync.floor = { ...state.sync.floor, snapshot: event.snapshot };
+      state.sync.floor = {
+        ...state.sync.floor,
+        snapshot: event.snapshot,
+        events: changedStream ? [] : state.sync.floor.events,
+      };
     } else {
       hydrateSnapshot(state, effects, event.snapshot, false);
     }
     return;
   }
+  if (event.streamId !== state.sync.streamId) return;
   if (state.sync.floor) {
     state.sync.floor = { ...state.sync.floor, events: [...state.sync.floor.events, event] };
     return;

--- a/apps/app/src/features/chat/runtime/chat-state.ts
+++ b/apps/app/src/features/chat/runtime/chat-state.ts
@@ -56,6 +56,7 @@ export type ChatState = {
     instance: "active" | "disposed";
   };
   sync: {
+    streamId: string | null;
     cursor: number;
     historyLoaded: boolean;
     floor: HistoryFloorState | null;
@@ -92,6 +93,7 @@ export function createChatState(): ChatState {
     outgoing: [],
     lifecycle: { session: "available", instance: "active" },
     sync: {
+      streamId: null,
       cursor: 0,
       historyLoaded: false,
       floor: null,

--- a/apps/app/src/features/chat/runtime/chat-subscription.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-subscription.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { RecoveringSubscription } from "./chat-subscription";
 
 const snapshot: SessionRuntimeSnapshot = {
+  streamId: "stream-1",
   ref: {
     projectId: "project-1",
     harnessAgentId: "claude-code",

--- a/apps/app/src/features/chat/runtime/chat-transport.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport.test.ts
@@ -13,6 +13,7 @@ const ref = {
 
 const snapshot: SessionRuntimeSnapshot = {
   ref,
+  streamId: "stream-1",
   status: { phase: "idle" },
   activeTurn: null,
   activePrompt: null,
@@ -99,12 +100,22 @@ describe("OrpcChatSessionTransport subscription", () => {
     let subscriptionCalls = 0;
     let snapshotSawSubscription = false;
     const items: SubscribeStreamEvent[] = [
-      { type: "event", event: { seq: 1, ref, type: "session.turn.started", turnId: "turn-1" } },
+      {
+        type: "event",
+        event: {
+          streamId: "stream-1",
+          seq: 1,
+          ref,
+          type: "session.turn.started",
+          turnId: "turn-1",
+        },
+      },
       // Collection events ride the same stream but are not session-scoped.
       { type: "event", event: { ref, type: "session.updated", title: "t" } },
       {
         type: "event",
         event: {
+          streamId: "stream-1",
           seq: 2,
           ref,
           type: "session.turn.ended",
@@ -157,7 +168,13 @@ describe("OrpcChatSessionTransport subscription", () => {
                 [
                   {
                     type: "event",
-                    event: { seq: 5, ref, type: "session.turn.started", turnId: "turn-2" },
+                    event: {
+                      streamId: "stream-1",
+                      seq: 5,
+                      ref,
+                      type: "session.turn.started",
+                      turnId: "turn-2",
+                    },
                   },
                 ],
                 drained,

--- a/apps/app/src/features/chat/runtime/chat-update.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.test.ts
@@ -13,6 +13,7 @@ const ref = {
 
 const snapshot = (overrides: Partial<SessionRuntimeSnapshot> = {}): SessionRuntimeSnapshot => ({
   ref,
+  streamId: "stream-1",
   status: { phase: "idle" },
   activeTurn: null,
   activePrompt: null,
@@ -379,10 +380,12 @@ describe("updateChat", () => {
     };
 
     const sequenced = createChatState();
+    sequenced.sync.streamId = "stream-1";
     sequenced.sync.cursor = 10;
     expectIgnored(sequenced, {
       type: "transportEvent",
       event: {
+        streamId: "stream-1",
         seq: 10,
         ref,
         type: "session.turn.started",

--- a/apps/app/src/features/chat/runtime/chat-update.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.test.ts
@@ -124,7 +124,7 @@ describe("updateChat", () => {
     const state: ChatState = {
       ...createChatState(),
       session: { ...createChatState().session, activeTurnId: "turn-1", status: "streaming" },
-      sync: { ...createChatState().sync, historyLoaded: true },
+      sync: { ...createChatState().sync, streamId: "stream-1", historyLoaded: true },
       outgoing: [
         {
           message: userMessage("follow", "afterwards"),
@@ -144,6 +144,7 @@ describe("updateChat", () => {
     const transition = updateChat(state, {
       type: "transportEvent",
       event: {
+        streamId: "stream-1",
         seq: 1,
         ref,
         type: "session.message.chunk",
@@ -167,6 +168,7 @@ describe("updateChat", () => {
     const state: ChatState = {
       ...createChatState(),
       session: { ...createChatState().session, activeTurnId: "turn-2", status: "streaming" },
+      sync: { ...createChatState().sync, streamId: "stream-1", historyLoaded: true },
       outgoing: [
         {
           message: userMessage("steer", "now"),
@@ -180,6 +182,7 @@ describe("updateChat", () => {
     const stale = updateChat(state, {
       type: "transportEvent",
       event: {
+        streamId: "stream-1",
         seq: 1,
         ref,
         type: "session.message.chunk",

--- a/apps/app/src/features/chat/runtime/chat-update.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.ts
@@ -94,7 +94,7 @@ export function updateChat(state: ChatState, input: ChatInput): ChatTransition {
     input.type === "transportEvent" &&
     input.event.type !== "attached" &&
     input.event.type !== "closed" &&
-    input.event.seq <= state.sync.cursor
+    (input.event.streamId !== state.sync.streamId || input.event.seq <= state.sync.cursor)
   ) {
     return { state, effects: [] };
   }

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -129,31 +129,47 @@ const makeChat = (options?: { onTerminated?: () => void }) => {
   const transport = new FakeTransport();
   const chat = new Chat({ sessionRef: ref, transport, onTerminated: options?.onTerminated });
   const emit = (event: ChatTransportEvent) => transport.onEvent?.(event);
+  let attachedStreamId = "stream-1";
   const attach = async (snapshot: Partial<SessionRuntimeSnapshot>) => {
-    emit({
-      type: "attached",
-      snapshot: {
-        ref,
-        status: { phase: "idle" },
-        activeTurn: null,
-        activePrompt: null,
-        acceptedPrompt: null,
-        acceptedPrompts: [],
-        pendingPrompts: [],
-        pendingRequests: [],
-        cursor: 0,
-        ...snapshot,
-      },
-    });
+    const nextSnapshot: SessionRuntimeSnapshot = {
+      ref,
+      streamId: attachedStreamId,
+      status: { phase: "idle" },
+      activeTurn: null,
+      activePrompt: null,
+      acceptedPrompt: null,
+      acceptedPrompts: [],
+      pendingPrompts: [],
+      pendingRequests: [],
+      cursor: 0,
+      ...snapshot,
+    };
+    attachedStreamId = nextSnapshot.streamId;
+    emit({ type: "attached", snapshot: nextSnapshot });
     await settle();
   };
-  const live = (seq: number, body: SessionScopedEventBody & { phase?: SessionPhase }) =>
-    emit({ seq, ref, ...body } as SessionScopedEvent);
+  const live = (
+    seq: number,
+    body: SessionScopedEventBody & { phase?: SessionPhase },
+    streamId = attachedStreamId,
+  ) => emit({ streamId, seq, ref, ...body } as SessionScopedEvent);
   return { chat, transport, attach, live, emit };
 };
 
-const chunkEvent = (seq: number, turnId: string, chunk: UIMessageChunk): SessionMessageChunkEvent =>
-  ({ seq, ref, type: "session.message.chunk", turnId, chunk }) as SessionMessageChunkEvent;
+const chunkEvent = (
+  seq: number,
+  turnId: string,
+  chunk: UIMessageChunk,
+  streamId = "stream-1",
+): SessionMessageChunkEvent =>
+  ({
+    streamId,
+    seq,
+    ref,
+    type: "session.message.chunk",
+    turnId,
+    chunk,
+  }) as SessionMessageChunkEvent;
 
 type ActiveTurnInit = Partial<NonNullable<SessionRuntimeSnapshot["activeTurn"]>> & {
   turnId: string;
@@ -193,18 +209,17 @@ const toolRequest: AgentRequest = {
 };
 
 describe("Chat hydration", () => {
-  // Reattaching across a server restart: the session's seq counter is rebuilt
-  // from scratch, so the next turn's events all land below the cursor we were
-  // holding. Keeping that cursor drops the entire turn and the page sits on a
-  // spinner forever — the exact failure a live restart produced.
-  it("rejoins from scratch when the server's seq counter has restarted", async () => {
+  // Reattaching across a server restart changes the explicit stream
+  // generation. Cursor values from the old process are irrelevant even when
+  // the replacement starts above them.
+  it("rejoins from scratch when the server stream changes", async () => {
     const { chat, transport, attach, live } = makeChat();
     transport.history = [userMessage("user-1", "hello")];
     await attach({ cursor: 8 });
     expect(chat.store.getState().session.messages).toHaveLength(1);
 
     transport.history = [userMessage("user-1", "hello")];
-    await attach({ cursor: 0 });
+    await attach({ streamId: "stream-2", cursor: 0 });
 
     const [start, delta, end] = textChunks("t", "after the restart");
     for (const [seq, chunk] of [start!, delta!, end!].entries()) {
@@ -215,6 +230,107 @@ describe("Chat hydration", () => {
     const last = chat.store.getState().session.messages.at(-1)!;
     expect(last.role).toBe("assistant");
     expect(assistantText(last)).toBe("after the restart");
+  });
+
+  it("resets cursor gating for a new stream even when its cursor is higher", async () => {
+    const { chat, attach } = makeChat();
+    await attach({ cursor: 8 });
+
+    await attach({
+      streamId: "stream-2",
+      activePrompt: {
+        messageId: "new-stream-prompt",
+        parts: [{ type: "text", text: "new generation" }],
+        seq: 2,
+        acceptedTurnId: null,
+      },
+      pendingPrompts: [
+        {
+          messageId: "new-stream-prompt",
+          parts: [{ type: "text", text: "new generation" }],
+          seq: 2,
+          acceptedTurnId: null,
+        },
+      ],
+      cursor: 10,
+    });
+
+    expect(chat.store.getState().messages.map((message) => message.id)).toContain(
+      "new-stream-prompt",
+    );
+  });
+
+  it("does not reset cursor gating for a lower snapshot on the same stream", async () => {
+    const { chat, attach, live } = makeChat();
+    await attach({ cursor: 8 });
+
+    await attach({
+      pendingPrompts: [
+        {
+          messageId: "already-past",
+          parts: [{ type: "text", text: "stale retained prompt" }],
+          seq: 3,
+          acceptedTurnId: null,
+        },
+      ],
+      cursor: 2,
+    });
+    live(7, { type: "session.turn.started", turnId: "stale-turn", phase: "running" });
+
+    expect(chat.store.getState().messages.map((message) => message.id)).not.toContain(
+      "already-past",
+    );
+    expect(chat.store.getState().status).toBe("ready");
+  });
+
+  it("ignores an old-stream live event after a new attach wins", async () => {
+    const { chat, attach, live } = makeChat();
+    await attach({ cursor: 8 });
+    await attach({ streamId: "stream-2", cursor: 10 });
+
+    live(100, { type: "session.turn.started", turnId: "old-turn", phase: "running" }, "stream-1");
+    expect(chat.store.getState().status).toBe("ready");
+
+    live(11, { type: "session.turn.started", turnId: "new-turn", phase: "running" });
+    expect(chat.store.getState().status).toBe("streaming");
+  });
+
+  it("drops buffered old-stream events when a new attach wins during the history floor", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    let releaseHistory: () => void = () => undefined;
+    transport.history = [];
+    transport.historyGate = new Promise((resolve) => {
+      releaseHistory = resolve;
+    });
+
+    await attach({});
+    live(1, {
+      type: "session.request.asked",
+      request: { ...toolRequest, id: "old-buffered" },
+      phase: "requires_action",
+    });
+    await attach({ streamId: "stream-2" });
+    live(
+      2,
+      {
+        type: "session.request.asked",
+        request: { ...toolRequest, id: "old-late" },
+        phase: "requires_action",
+      },
+      "stream-1",
+    );
+    live(1, {
+      type: "session.request.asked",
+      request: { ...toolRequest, id: "new-buffered" },
+      phase: "requires_action",
+    });
+
+    releaseHistory();
+    await settle();
+
+    expect(chat.store.getState().pendingRequests.map((request) => request.id)).toEqual([
+      "new-buffered",
+    ]);
   });
 
   it("keeps a pending prompt across a restarted server snapshot", async () => {
@@ -232,7 +348,7 @@ describe("Chat hydration", () => {
     // The rebuilt server starts at cursor zero and has not accepted the prompt
     // yet, so neither its idle phase nor its settled history may erase the
     // optimistic bubble.
-    await attach({ cursor: 0 });
+    await attach({ streamId: "stream-2", cursor: 0 });
     expect(chat.store.getState().session.messages.map((message) => message.role)).toEqual([
       "user",
       "user",
@@ -276,6 +392,7 @@ describe("Chat hydration", () => {
       },
     ];
     await attach({
+      streamId: "stream-2",
       activePrompt: {
         messageId,
         parts: [{ type: "text", text: "still queued" }],
@@ -1360,9 +1477,14 @@ describe("Chat prompting", () => {
         .map((message) => message.message),
     ).toHaveLength(1);
 
-    // The queue belongs to the Chat, so a server-side runtime rebuild does not
-    // erase it. The fresh idle snapshot is the next safe dispatch boundary.
-    await attach({ status: { phase: "idle" }, activeTurn: null, cursor: 0 });
+    // The queue belongs to the Chat, so a new server-side session incarnation
+    // does not erase it. The fresh idle snapshot is the next safe boundary.
+    await attach({
+      streamId: "stream-2",
+      status: { phase: "idle" },
+      activeTurn: null,
+      cursor: 0,
+    });
     await queued;
 
     expect(transport.promptCalls).toHaveLength(1);

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -255,7 +255,7 @@ describe("Chat hydration", () => {
       cursor: 10,
     });
 
-    expect(chat.store.getState().messages.map((message) => message.id)).toContain(
+    expect(chat.store.getState().session.messages.map((message) => message.id)).toContain(
       "new-stream-prompt",
     );
   });
@@ -277,10 +277,10 @@ describe("Chat hydration", () => {
     });
     live(7, { type: "session.turn.started", turnId: "stale-turn", phase: "running" });
 
-    expect(chat.store.getState().messages.map((message) => message.id)).not.toContain(
+    expect(chat.store.getState().session.messages.map((message) => message.id)).not.toContain(
       "already-past",
     );
-    expect(chat.store.getState().status).toBe("ready");
+    expect(chat.store.getState().session.status).toBe("ready");
   });
 
   it("ignores an old-stream live event after a new attach wins", async () => {
@@ -289,10 +289,10 @@ describe("Chat hydration", () => {
     await attach({ streamId: "stream-2", cursor: 10 });
 
     live(100, { type: "session.turn.started", turnId: "old-turn", phase: "running" }, "stream-1");
-    expect(chat.store.getState().status).toBe("ready");
+    expect(chat.store.getState().session.status).toBe("ready");
 
     live(11, { type: "session.turn.started", turnId: "new-turn", phase: "running" });
-    expect(chat.store.getState().status).toBe("streaming");
+    expect(chat.store.getState().session.status).toBe("streaming");
   });
 
   it("drops buffered old-stream events when a new attach wins during the history floor", async () => {
@@ -328,7 +328,7 @@ describe("Chat hydration", () => {
     releaseHistory();
     await settle();
 
-    expect(chat.store.getState().pendingRequests.map((request) => request.id)).toEqual([
+    expect(chat.store.getState().session.pendingRequests.map((request) => request.id)).toEqual([
       "new-buffered",
     ]);
   });

--- a/apps/app/src/features/projects/session-list-cache.test.ts
+++ b/apps/app/src/features/projects/session-list-cache.test.ts
@@ -39,6 +39,7 @@ describe("applySessionListEvent", () => {
     const queryClient = seed([row()]);
     const event: ServerEvent = {
       ref,
+      streamId: "stream-1",
       seq: 1,
       type: "session.turn.started",
       turnId: "turn-1",
@@ -53,6 +54,7 @@ describe("applySessionListEvent", () => {
     const before = rows(queryClient);
     const event: ServerEvent = {
       ref,
+      streamId: "stream-1",
       seq: 2,
       type: "session.turn.started",
       turnId: "turn-1",
@@ -67,6 +69,7 @@ describe("applySessionListEvent", () => {
     const before = rows(queryClient);
     const event: ServerEvent = {
       ref,
+      streamId: "stream-1",
       seq: 3,
       type: "session.message.chunk",
       turnId: "turn-1",

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -256,10 +256,12 @@ export type SessionScopedEventBody =
     }
   | { readonly type: "session.crashed"; readonly reason: string };
 
-/** A session-scoped event before the server's `HarnessAgentSession` stamps its `seq`. */
+/** A session-scoped event before `HarnessAgentSession` stamps its `streamId` and `seq`. */
 export type SessionScopedEventDraft = { readonly ref: SessionRef } & SessionScopedEventBody;
 
 export type SessionScopedEvent = {
+  /** Process-local incarnation of this ref's server-side session state. */
+  readonly streamId: string;
   readonly seq: number;
   /**
    * The session's phase *after* this event applied, stamped by the server's
@@ -486,6 +488,8 @@ export type HarnessProbeOutput = typeof HarnessProbeOutputSchema.Type;
 
 export type SessionRuntimeSnapshot = {
   readonly ref: SessionRef;
+  /** Process-local incarnation whose cursor and retained events this snapshot describes. */
+  readonly streamId: string;
   readonly status: SessionStatus;
   readonly pendingRequests: ReadonlyArray<AgentRequest>;
   readonly activeTurn: ActiveTurnSnapshot | null;

--- a/packages/contract/test/schema.test.ts
+++ b/packages/contract/test/schema.test.ts
@@ -154,6 +154,7 @@ describe("event partition", () => {
   it("isSessionScopedEvent splits the union", () => {
     const chunk: ServerEvent = {
       ref,
+      streamId: "stream-1",
       seq: 1,
       type: "session.turn.started",
       turnId: "t1",

--- a/packages/server/src/harness/session-fold.ts
+++ b/packages/server/src/harness/session-fold.ts
@@ -303,8 +303,13 @@ export const toStatus = (state: SessionState): SessionStatus => ({
     : {}),
 });
 
-export const toSnapshot = (ref: SessionRef, state: SessionState): SessionRuntimeSnapshot => ({
+export const toSnapshot = (
+  ref: SessionRef,
+  streamId: string,
+  state: SessionState,
+): SessionRuntimeSnapshot => ({
   ref,
+  streamId,
   status: toStatus(state),
   pendingRequests: [...state.pendingRequests.values()],
   activeTurn: state.activeTurn

--- a/packages/server/src/harness/session-manager.ts
+++ b/packages/server/src/harness/session-manager.ts
@@ -5,7 +5,17 @@ import type {
   SessionScopedEventBody,
   SessionStatus,
 } from "@vibest/contract";
-import { Context, Deferred, Effect, FileSystem, Layer, Ref, Scope } from "effect";
+import {
+  Context,
+  Crypto,
+  Deferred,
+  Effect,
+  FileSystem,
+  Layer,
+  Ref,
+  Scope,
+  Semaphore,
+} from "effect";
 
 import { EventBus, type EventBusShape } from "../events/event-bus";
 import type { CreateSessionInput, HarnessAgentRuntime } from "./adapter";
@@ -136,7 +146,11 @@ export class HarnessAgentSessionManager extends Context.Service<
  */
 type SessionEntry =
   | { readonly _tag: "Live"; readonly session: HarnessAgentSessionShape }
-  | { readonly _tag: "Closing"; readonly done: Deferred.Deferred<void> };
+  | {
+      readonly _tag: "Closing";
+      readonly done: Deferred.Deferred<void>;
+      readonly streamId: string;
+    };
 
 type CloseStep =
   | {
@@ -147,10 +161,21 @@ type CloseStep =
   | { readonly _tag: "Await"; readonly done: Deferred.Deferred<void> }
   | { readonly _tag: "Done" };
 
+type SessionForStep =
+  | { readonly _tag: "Ready"; readonly session: HarnessAgentSessionShape }
+  | { readonly _tag: "AwaitClose"; readonly done: Deferred.Deferred<void> };
+
+type MakeSession = typeof makeHarnessAgentSession;
+
 export const makeHarnessAgentSessionManager = (
   registry: HarnessAgentRegistryShape,
   bus: EventBusShape,
-): Effect.Effect<HarnessAgentSessionManagerShape, never, Scope.Scope | FileSystem.FileSystem> =>
+  makeSession: MakeSession = makeHarnessAgentSession,
+): Effect.Effect<
+  HarnessAgentSessionManagerShape,
+  never,
+  Scope.Scope | FileSystem.FileSystem | Crypto.Crypto
+> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
     // An adapter's availability check reads the filesystem; bind it once here
@@ -158,45 +183,68 @@ export const makeHarnessAgentSessionManager = (
     // `provide(Effect.context())` — the latter captures the whole layer-build
     // context, `ownerScope` included, and wins the merge over a caller's.
     const fileSystem = yield* FileSystem.FileSystem;
+    const crypto = yield* Crypto.Crypto;
+    const serverStreamId = yield* crypto.randomUUIDv4.pipe(
+      Effect.catchTag("PlatformError", (cause) =>
+        Effect.die(new Error("invariant: platform RNG failed minting a stream id", { cause })),
+      ),
+    );
+    // The server id changes on process/manager restart. A session's epoch stays
+    // stable while it is absent and across its first materialization, then
+    // advances exactly once when that live session closes.
+    const streamEpochs = yield* Ref.make<ReadonlyMap<string, number>>(new Map());
+    const streamIdFor = (ref: SessionRef): Effect.Effect<string> =>
+      Ref.get(streamEpochs).pipe(
+        Effect.map((epochs) => {
+          const epoch = epochs.get(ref.sessionId) ?? 0;
+          return `${serverStreamId}:${ref.sessionId.length}:${ref.sessionId}:${epoch}`;
+        }),
+      );
+    const advanceStreamEpoch = (ref: SessionRef): Effect.Effect<void> =>
+      Ref.update(streamEpochs, (current) => {
+        const next = new Map(current);
+        next.set(ref.sessionId, (current.get(ref.sessionId) ?? 0) + 1);
+        return next;
+      });
     // Our sessionId → the session that owns its observable state.
     const sessions = yield* Ref.make<ReadonlyMap<string, SessionEntry>>(new Map());
+    // Session construction is only a handful of Refs. Keep lookup, construction,
+    // and install under one permit so close cannot observe an absent table entry
+    // and return while an already-started materialization installs afterwards.
+    const sessionTableLock = Semaphore.makeUnsafe(1);
 
-    /** The session for a ref, on the write paths that are allowed to create
-     * one. A session is a few Refs, so losing the creation race and discarding
-     * the loser costs nothing — cheaper than serializing every lookup. */
     const sessionFor = (ref: SessionRef): Effect.Effect<HarnessAgentSessionShape> =>
       Effect.suspend(() =>
-        Ref.get(sessions).pipe(
-          Effect.flatMap((current) => {
-            const entry = current.get(ref.sessionId);
-            if (entry?._tag === "Live") return Effect.succeed(entry.session);
-            if (entry?._tag === "Closing")
-              return Deferred.await(entry.done).pipe(Effect.andThen(sessionFor(ref)));
-            return makeHarnessAgentSession(ref, bus).pipe(
-              Effect.provideService(Scope.Scope, ownerScope),
-              Effect.flatMap((candidate) =>
-                Ref.modify(
-                  sessions,
-                  (
-                    latest,
-                  ): readonly [
-                    HarnessAgentSessionShape | undefined,
-                    ReadonlyMap<string, SessionEntry>,
-                  ] => {
-                    const raced = latest.get(ref.sessionId);
-                    if (raced?._tag === "Live") return [raced.session, latest];
-                    if (raced?._tag === "Closing") return [undefined, latest];
-                    return [
-                      candidate,
-                      new Map(latest).set(ref.sessionId, { _tag: "Live", session: candidate }),
-                    ];
-                  },
-                ),
-              ),
-              Effect.flatMap((session) => (session ? Effect.succeed(session) : sessionFor(ref))),
-            );
-          }),
-        ),
+        sessionTableLock
+          .withPermit(
+            Ref.get(sessions).pipe(
+              Effect.flatMap((current): Effect.Effect<SessionForStep> => {
+                const entry = current.get(ref.sessionId);
+                if (entry?._tag === "Live") {
+                  return Effect.succeed({ _tag: "Ready", session: entry.session });
+                }
+                if (entry?._tag === "Closing") {
+                  return Effect.succeed({ _tag: "AwaitClose", done: entry.done });
+                }
+                return streamIdFor(ref).pipe(
+                  Effect.flatMap((streamId) => makeSession(ref, streamId, bus)),
+                  Effect.provideService(Scope.Scope, ownerScope),
+                  Effect.flatMap((session) =>
+                    Ref.update(sessions, (latest) =>
+                      new Map(latest).set(ref.sessionId, { _tag: "Live", session }),
+                    ).pipe(Effect.as({ _tag: "Ready", session } as const)),
+                  ),
+                );
+              }),
+            ),
+          )
+          .pipe(
+            Effect.flatMap((step) =>
+              step._tag === "Ready"
+                ? Effect.succeed(step.session)
+                : Deferred.await(step.done).pipe(Effect.andThen(sessionFor(ref))),
+            ),
+          ),
       );
 
     /** Read through a live session, or answer for one that isn't there. One on
@@ -284,29 +332,55 @@ export const makeHarnessAgentSessionManager = (
     // gone: removing it first would let a concurrent write build a second
     // session for the same ref and resume it alongside the one still dying.
     const close = (ref: SessionRef): Effect.Effect<void> =>
-      Ref.modify(sessions, (current): readonly [CloseStep, ReadonlyMap<string, SessionEntry>] => {
-        const entry = current.get(ref.sessionId);
-        if (!entry) return [{ _tag: "Done" }, current];
-        if (entry._tag === "Closing") return [{ _tag: "Await", done: entry.done }, current];
-        const done = Deferred.makeUnsafe<void>();
-        return [
-          { _tag: "Release", session: entry.session, done },
-          new Map(current).set(ref.sessionId, { _tag: "Closing", done }),
-        ];
-      }).pipe(
-        Effect.flatMap((step) => {
-          if (step._tag === "Done") return Effect.void;
-          if (step._tag === "Await") return Deferred.await(step.done);
-          return step.session.releaseRuntime.pipe(
-            Effect.ensuring(
-              Ref.update(sessions, (current) => {
-                const entry = current.get(ref.sessionId);
-                if (entry?._tag !== "Closing" || entry.done !== step.done) return current;
-                const next = new Map(current);
-                next.delete(ref.sessionId);
-                return next;
-              }).pipe(Effect.andThen(Deferred.succeed(step.done, undefined))),
-            ),
+      sessionTableLock
+        .withPermit(
+          Ref.modify(
+            sessions,
+            (current): readonly [CloseStep, ReadonlyMap<string, SessionEntry>] => {
+              const entry = current.get(ref.sessionId);
+              if (!entry) return [{ _tag: "Done" }, current];
+              if (entry._tag === "Closing") return [{ _tag: "Await", done: entry.done }, current];
+              const done = Deferred.makeUnsafe<void>();
+              return [
+                { _tag: "Release", session: entry.session, done },
+                new Map(current).set(ref.sessionId, {
+                  _tag: "Closing",
+                  done,
+                  streamId: entry.session.streamId,
+                }),
+              ];
+            },
+          ),
+        )
+        .pipe(
+          Effect.flatMap((step) => {
+            if (step._tag === "Done") return Effect.void;
+            if (step._tag === "Await") return Deferred.await(step.done);
+            return advanceStreamEpoch(ref).pipe(
+              Effect.andThen(step.session.releaseRuntime),
+              Effect.ensuring(
+                Ref.update(sessions, (current) => {
+                  const entry = current.get(ref.sessionId);
+                  if (entry?._tag !== "Closing" || entry.done !== step.done) return current;
+                  const next = new Map(current);
+                  next.delete(ref.sessionId);
+                  return next;
+                }).pipe(Effect.andThen(Deferred.succeed(step.done, undefined))),
+              ),
+            );
+          }),
+        );
+
+    const snapshot = (ref: SessionRef): Effect.Effect<SessionRuntimeSnapshot> =>
+      Ref.get(sessions).pipe(
+        Effect.flatMap((current) => {
+          const entry = current.get(ref.sessionId);
+          if (entry?._tag === "Live") return entry.session.snapshot;
+          if (entry?._tag === "Closing") {
+            return Effect.succeed(toSnapshot(ref, entry.streamId, initialSessionState));
+          }
+          return streamIdFor(ref).pipe(
+            Effect.map((streamId) => toSnapshot(ref, streamId, initialSessionState)),
           );
         }),
       );
@@ -361,8 +435,7 @@ export const makeHarnessAgentSessionManager = (
         sessionFor(ref).pipe(Effect.flatMap((session) => session.setConfig(patch))),
       close,
       status: (ref) => withSession(ref, (session) => session.status, toStatus(initialSessionState)),
-      snapshot: (ref) =>
-        withSession(ref, (session) => session.snapshot, toSnapshot(ref, initialSessionState)),
+      snapshot,
       liveStatus: (ref) =>
         withSession<SessionStatus | undefined>(ref, (session) => session.status, undefined),
       emit: (ref, body) => sessionFor(ref).pipe(Effect.flatMap((session) => session.emit(body))),

--- a/packages/server/src/harness/session.ts
+++ b/packages/server/src/harness/session.ts
@@ -156,6 +156,7 @@ const pushConfig = (
 
 export type HarnessAgentSessionShape = {
   readonly ref: SessionRef;
+  readonly streamId: string;
   /**
    * What this session is doing, always answerable. A session that has never
    * had a runtime reads as idle at cursor 0 — which is the truth, not a
@@ -205,6 +206,7 @@ export type HarnessAgentSessionShape = {
 
 export const makeHarnessAgentSession = (
   ref: SessionRef,
+  streamId: string,
   bus: EventBusShape,
 ): Effect.Effect<HarnessAgentSessionShape, never, Scope.Scope> =>
   Effect.gen(function* () {
@@ -256,7 +258,12 @@ export const makeHarnessAgentSession = (
             Effect.flatMap((current) => {
               const wireBody = make(current);
               if (!wireBody) return Effect.void;
-              const event: SessionScopedEvent = { seq: current.seq + 1, ref, ...wireBody };
+              const event: SessionScopedEvent = {
+                streamId,
+                seq: current.seq + 1,
+                ref,
+                ...wireBody,
+              };
               const next = foldSessionEvent(current, event);
               // Publish with the post-fold phase stamped on: consumers copy the
               // session's phase off the event instead of re-deriving it from
@@ -441,7 +448,8 @@ export const makeHarnessAgentSession = (
 
     return {
       ref,
-      snapshot: Ref.get(state).pipe(Effect.map((current) => toSnapshot(ref, current))),
+      streamId,
+      snapshot: Ref.get(state).pipe(Effect.map((current) => toSnapshot(ref, streamId, current))),
       status: Ref.get(state).pipe(Effect.map(toStatus)),
       emit: (body) => applyWith(() => body),
       setConfig,

--- a/packages/server/test/event-bus-overflow.test.ts
+++ b/packages/server/test/event-bus-overflow.test.ts
@@ -9,6 +9,7 @@ import { makeEventBus } from "../src/events";
 const ref: SessionRef = { projectId: "p1", harnessAgentId: "claude-code", sessionId: "s1" };
 
 const started = (seq: number): SessionScopedEvent => ({
+  streamId: "stream-1",
   seq,
   ref,
   type: "session.turn.started",

--- a/packages/server/test/events.test.ts
+++ b/packages/server/test/events.test.ts
@@ -13,6 +13,7 @@ const ref = (sessionId: string): SessionRef => ({
 });
 
 const started = (sessionId: string, seq: number): SessionScopedEvent => ({
+  streamId: "stream-1",
   seq,
   ref: ref(sessionId),
   type: "session.turn.started",

--- a/packages/server/test/harness/session-fold.test.ts
+++ b/packages/server/test/harness/session-fold.test.ts
@@ -12,6 +12,7 @@ const ref: SessionRef = {
 const event = (seq: number, body: SessionScopedEventBody): SessionScopedEvent => ({
   ...body,
   ref,
+  streamId: "stream-1",
   seq,
 });
 
@@ -42,7 +43,7 @@ describe("session prompt projection", () => {
       }),
     );
 
-    expect(toSnapshot(ref, state)).toMatchObject({
+    expect(toSnapshot(ref, "stream-1", state)).toMatchObject({
       activePrompt: { messageId: "prompt-b", acceptedTurnId: null },
       acceptedPrompt: { messageId: "prompt-a", acceptedTurnId: "turn-a" },
       acceptedPrompts: [{ messageId: "prompt-a", acceptedTurnId: "turn-a" }],
@@ -58,7 +59,7 @@ describe("session prompt projection", () => {
       }),
     );
 
-    expect(toSnapshot(ref, state).activePrompt).toMatchObject({
+    expect(toSnapshot(ref, "stream-1", state).activePrompt).toMatchObject({
       messageId: "prompt-a",
       acceptedTurnId: "turn-a",
     });

--- a/packages/server/test/harness/session-fold.test.ts
+++ b/packages/server/test/harness/session-fold.test.ts
@@ -97,7 +97,7 @@ describe("session prompt projection", () => {
       event(5, { type: "session.prompt.accepted", messageId: "steer-a", turnId: "turn-1" }),
     );
 
-    expect(toSnapshot(ref, state).acceptedPrompts).toEqual([
+    expect(toSnapshot(ref, "stream-1", state).acceptedPrompts).toEqual([
       {
         messageId: "steer-a",
         parts: [{ type: "text", text: "A" }],
@@ -116,7 +116,7 @@ describe("session prompt projection", () => {
       state,
       event(6, { type: "session.turn.ended", turnId: "turn-1", outcome: "completed" }),
     );
-    expect(toSnapshot(ref, state)).toMatchObject({
+    expect(toSnapshot(ref, "stream-1", state)).toMatchObject({
       acceptedPrompt: null,
       acceptedPrompts: [],
     });

--- a/packages/server/test/harness/session-manager.test.ts
+++ b/packages/server/test/harness/session-manager.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import type { SessionRef } from "@vibest/contract";
 import type { ClaudeCodeUIMessageChunk } from "@vibest/contract/claude-code";
-import { Deferred, Effect, Exit, Fiber, Queue, Ref, Scope } from "effect";
+import { Deferred, Effect, Exit, Fiber, Queue, Ref, Scope, Stream } from "effect";
 import type * as Cause from "effect/Cause";
 
 import { makeEventBus } from "../../src/events/event-bus";
@@ -17,6 +17,7 @@ import { AgentOperationError } from "../../src/harness/errors";
 import type { SessionEnvelopeDraft, SessionEvent } from "../../src/harness/events/framework";
 import { streamFromQueueOne } from "../../src/harness/queue-stream";
 import { makeHarnessAgentRegistry } from "../../src/harness/registry";
+import { makeHarnessAgentSession } from "../../src/harness/session";
 import { makeHarnessAgentSessionManager } from "../../src/harness/session-manager";
 import { NodePlatformLayer } from "../platform";
 
@@ -127,6 +128,7 @@ const makeFixture = Effect.gen(function* () {
 
   return {
     manager,
+    bus,
     resumeGate,
     resumeCalls,
     closeCalls,
@@ -135,7 +137,6 @@ const makeFixture = Effect.gen(function* () {
     crashGate,
   };
 });
-
 type Fixture = Effect.Success<typeof makeFixture>;
 
 /** Liveness probe: `get` succeeds while a session has a runtime, fails once torn down. */
@@ -172,6 +173,86 @@ it.effect("drains the native stream into the session and tears down on close", (
   }),
 );
 
+it.effect("keeps one stream id per session generation", () =>
+  Effect.gen(function* () {
+    const fixture = yield* makeFixture;
+    const ref = refFor("generation");
+
+    const firstAbsent = yield* fixture.manager.snapshot(ref);
+    const secondAbsent = yield* fixture.manager.snapshot(ref);
+    assert.equal(secondAbsent.streamId, firstAbsent.streamId);
+
+    yield* fixture.manager.open("claude-code", { cwd: "/tmp" }, {}, ref);
+    const firstLive = yield* fixture.manager.snapshot(ref);
+    assert.equal(firstLive.streamId, firstAbsent.streamId);
+
+    const stream = yield* fixture.bus.subscribe({ kind: "session", ref });
+    const eventFiber = yield* Effect.forkChild(Stream.runHead(stream));
+    yield* fixture.manager.emit(ref, { type: "session.turn.started", turnId: "turn-1" });
+    const item = yield* Fiber.join(eventFiber);
+    assert.equal(item._tag, "Some");
+    const event =
+      item._tag === "Some" && item.value.type === "event" ? item.value.event : undefined;
+    assert.equal(event && "streamId" in event ? event.streamId : undefined, firstLive.streamId);
+    assert.equal((yield* fixture.manager.snapshot(ref)).streamId, firstLive.streamId);
+
+    yield* fixture.manager.close(ref);
+    const secondAbsentGeneration = yield* fixture.manager.snapshot(ref);
+    assert.notEqual(secondAbsentGeneration.streamId, firstLive.streamId);
+    assert.equal((yield* fixture.manager.snapshot(ref)).streamId, secondAbsentGeneration.streamId);
+
+    yield* fixture.manager.open("claude-code", { cwd: "/tmp" }, {}, ref);
+    const secondLive = yield* fixture.manager.snapshot(ref);
+    assert.equal(secondLive.streamId, secondAbsentGeneration.streamId);
+    yield* fixture.manager.close(ref);
+
+    const restarted = yield* makeFixture;
+    assert.notEqual((yield* restarted.manager.snapshot(ref)).streamId, firstAbsent.streamId);
+  }),
+);
+
+const makeCreationRaceManager = (
+  started: Deferred.Deferred<void>,
+  release: Deferred.Deferred<void>,
+) =>
+  Effect.gen(function* () {
+    const registry = makeHarnessAgentRegistry([]);
+    const bus = yield* makeEventBus();
+    const makeSession: typeof makeHarnessAgentSession = (...args) =>
+      Deferred.succeed(started, undefined).pipe(
+        Effect.andThen(Deferred.await(release)),
+        Effect.andThen(makeHarnessAgentSession(...args)),
+      );
+    return yield* makeHarnessAgentSessionManager(registry, bus, makeSession).pipe(
+      Effect.provide(NodePlatformLayer),
+    );
+  });
+
+it.effect("close waits for a session materialization that already owns the table permit", () =>
+  Effect.gen(function* () {
+    const started = yield* Deferred.make<void>();
+    const release = yield* Deferred.make<void>();
+    const manager = yield* makeCreationRaceManager(started, release);
+    const ref = refFor("creation-close-race");
+
+    const materialize = yield* Effect.forkChild(
+      manager.emit(ref, { type: "session.turn.started", turnId: "turn-1" }),
+    );
+    yield* Deferred.await(started);
+
+    const close = yield* Effect.forkChild(manager.close(ref));
+    yield* Effect.yieldNow;
+    assert.equal(close.pollUnsafe(), undefined);
+
+    yield* Deferred.succeed(release, undefined);
+    yield* Fiber.join(materialize);
+    yield* Fiber.join(close);
+
+    assert.equal(yield* manager.liveStatus(ref), undefined);
+    assert.equal((yield* manager.snapshot(ref)).cursor, 0);
+  }),
+);
+
 it.effect("single-flights ensure in owner scope when the first waiter cancels", () =>
   Effect.gen(function* () {
     const fixture = yield* makeFixture;
@@ -203,6 +284,7 @@ it.effect("waits for an in-flight close before reopening the same session id", (
     const fixture = yield* makeFixture;
     const ref = refFor("created");
     const session = yield* fixture.manager.open("claude-code", { cwd: "/tmp" }, {}, ref);
+    const closingStreamId = (yield* fixture.manager.snapshot(ref)).streamId;
     yield* Ref.set(fixture.holdClose, true);
     const close = yield* Effect.forkChild(fixture.manager.close(ref));
     yield* Effect.eventually(
@@ -213,6 +295,7 @@ it.effect("waits for an in-flight close before reopening the same session id", (
         ),
       ),
     );
+    assert.equal((yield* fixture.manager.snapshot(ref)).streamId, closingStreamId);
     const resume = yield* Effect.forkChild(
       fixture.manager.ensureRuntime(
         { sessionId: session.sessionId, harnessAgentId: "claude-code" },
@@ -236,6 +319,7 @@ it.effect("waits for an in-flight close before reopening the same session id", (
     yield* Fiber.join(resume);
 
     assert.equal(yield* isActive(fixture, ref), true);
+    assert.notEqual((yield* fixture.manager.snapshot(ref)).streamId, closingStreamId);
     yield* fixture.manager.close(ref);
   }),
 );

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -181,7 +181,9 @@ describe("HarnessAgentSessionService", () => {
           const build: Effect.Effect<Fixture, never, Scope.Scope | FileSystem.FileSystem> =
             Effect.gen(function* () {
               const bus = yield* makeEventBus();
-              const manager = yield* makeHarnessAgentSessionManager(registry, bus);
+              const manager = yield* makeHarnessAgentSessionManager(registry, bus).pipe(
+                Effect.provideService(Crypto.Crypto, crypto),
+              );
               const repo = yield* makeHarnessAgentSessionRepository(
                 path.join(home, "storage", "sessions"),
               );
@@ -512,14 +514,25 @@ describe("HarnessAgentSessionService", () => {
     const result = await run({ coldHistory: history }, (fixture) =>
       Effect.gen(function* () {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        const originalSnapshot = yield* fixture.service.getSnapshot(ref);
         const restarted = yield* fixture.restart;
 
         yield* restarted.service.prepare(ref, "/tmp/vibest-app");
         const status = yield* restarted.service.getStatus(ref);
         const snapshot = yield* restarted.service.getSnapshot(ref);
+        const repeatedSnapshot = yield* restarted.service.getSnapshot(ref);
         const listed = yield* restarted.service.list("proj-a", false);
         const messages = yield* restarted.service.getMessages(ref, "/tmp/vibest-app");
-        return { ref, status, snapshot, listed, messages, spy: fixture.spy };
+        return {
+          ref,
+          originalSnapshot,
+          status,
+          snapshot,
+          repeatedSnapshot,
+          listed,
+          messages,
+          spy: fixture.spy,
+        };
       }),
     );
 
@@ -527,6 +540,8 @@ describe("HarnessAgentSessionService", () => {
     expect(result.status).toEqual({ phase: "idle" });
     expect(result.snapshot.cursor).toBe(0);
     expect(result.snapshot.activeTurn).toBeNull();
+    expect(result.snapshot.streamId).toBe(result.repeatedSnapshot.streamId);
+    expect(result.snapshot.streamId).not.toBe(result.originalSnapshot.streamId);
     expect(result.messages).toEqual(history);
     // … a session nothing has touched carries no status at all, so the sidebar
     // does not light up every row as active …

--- a/packages/server/test/harness/session.test.ts
+++ b/packages/server/test/harness/session.test.ts
@@ -28,7 +28,7 @@ const SessionServiceLayer = Layer.effect(
   SessionService,
   Effect.gen(function* () {
     const bus = yield* EventBus;
-    return yield* makeHarnessAgentSession(ref, bus);
+    return yield* makeHarnessAgentSession(ref, "stream-1", bus);
   }),
 );
 
@@ -106,6 +106,7 @@ it.effect("a session that never had a runtime reads as idle at cursor 0", () =>
       const session = yield* SessionService;
       assert.equal(yield* session.peekRuntime, undefined);
       const snapshot = yield* session.snapshot;
+      assert.equal(snapshot.streamId, "stream-1");
       assert.equal(snapshot.status.phase, "idle");
       assert.equal(snapshot.cursor, 0);
       assert.equal(snapshot.activeTurn, null);

--- a/packages/server/test/observability/turn-log.test.ts
+++ b/packages/server/test/observability/turn-log.test.ts
@@ -31,7 +31,7 @@ layer(Layer.empty)("turn logging", (it) => {
   // the whole block.
   const session = Effect.gen(function* () {
     const bus = Context.get(yield* Layer.build(EventBusLayer), EventBus);
-    return yield* makeHarnessAgentSession(ref, bus);
+    return yield* makeHarnessAgentSession(ref, "stream-1", bus);
   });
 
   it.effect("logs the two bookends and nothing in between", () =>


### PR DESCRIPTION
## Summary

- add a required `streamId` to session-scoped events and runtime snapshots
- compare cursors only within the same server-side session generation
- reset client recovery state when a new stream generation attaches, even when its cursor already exceeds the previous cursor
- ignore stale events from prior generations and discard buffered old-generation events when a newer attach wins
- keep absent snapshots and first live materialization on the same stream ID
- advance a per-session stream epoch on close/reopen and generate a new server ID after process restart
- serialize lightweight session materialization with close reservation so close cannot miss an in-progress session install

## Validation

- full `pnpm test`
- full `pnpm check`
- contract: 38 tests
- app: 156 tests
- server: 379 passed / 2 skipped
- desktop: 43 tests
- `git diff --check`
- independent review: no significant findings

### Real browser / Pi

With the page left open:

1. completed `BEFORE_RESTART_DONE`
2. fully stopped and restarted the API process
3. submitted a prompt to the cold session and received `AFTER_RESTART_DONE`
4. queued a follow-up during that turn and received `QUEUED_AFTER_RESTART_DONE`

The transcript remained ordered, the queue drained, and the page marker/URL stayed unchanged.

## Compatibility

This changes the session event/snapshot wire shape. Client and server should be upgraded together; `streamId` is deliberately process-local and is not persisted.

## Stack

Depends on #248.
