### PR TITLE
fix(chat): guard interrupted turns after restart

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,19 @@ A client connecting to a session's live event stream — `session.subscribe` plu
 _Avoid_: attach for the cold pre-flight (its former name) or for taking a Chat instance; resume (`session.prepare` starts nothing — only a prompt does)
 
 **Session metadata**:
-The server-owned recovery record for a session: which Project, which harness agent, which harness session id, and whether the session is archived. Distinct from conversation history, which stays in the agent's native storage.
+The server-owned identity record for a session: which Project, which harness agent, which harness session id, and whether the session is archived. Distinct from conversation history and from a Recovery barrier.
+
+**Session stream**:
+One process-local incarnation of a session's observable server state, identified by `streamId`; `seq` and cursor comparisons are meaningful only inside that stream. A server restart or explicit close/reopen creates a new stream.
+_Avoid_: treating a bare numeric cursor as globally comparable
+
+**Recovery barrier**:
+A durable record that an earlier server process may have left a turn unresolved. It records the uncertain prompts, permits history inspection, and blocks all future prompts until the user explicitly acknowledges the unknown outcome. Acknowledgement permits future work; it does not replay, resume, interrupt, roll back, or declare the old turn complete.
+_Avoid_: active-turn resume, automatic retry, recovered turn
+
+**Active-turn continuation**:
+Reattaching to the same still-running native execution without starting a second executor. No current harness adapter provides this guarantee; Recovery barrier behavior is not active-turn continuation.
+_Avoid_: resume (`adapter.resume` restores session context for future work, not an interrupted execution)
 
 **Workspace path**:
 The validated absolute directory handed to a harness agent when opening or resuming a session; always derived from `Project.path`, never accepted directly from session API callers.
@@ -43,7 +55,7 @@ The per-harness door (descriptor, availability, probes, open/resume factory, col
 _Avoid_: HarnessAgentSession for the runtime (it is the in-memory session; see below)
 
 **Private modules** (no Context tags, never wired directly):
-`harness/session.ts` — **HarnessAgentSession**, one session as this server sees it: seq stamping, phase, buffers, pending requests, and the single-flight lifecycle of the runtime it _optionally_ owns. A crash releases the runtime but leaves the session queryable (phase "crashed") until an explicit `close`. `harness/session-fold.ts` — the pure state fold it applies (no Effect, no I/O). `harness/session-repository.ts` — the service's metadata store over `storage/sessions/`.
+`harness/session.ts` — **HarnessAgentSession**, one session as this server sees it: seq stamping, phase, buffers, pending requests, and the single-flight lifecycle of the runtime it _optionally_ owns. A crash releases the runtime but leaves the session queryable (phase "crashed") until an explicit `close`. `harness/session-fold.ts` — the pure state fold it applies (no Effect, no I/O). `harness/session-repository.ts` — the service's identity metadata store over `storage/sessions/`. `harness/session-recovery.ts` — the separate durable Recovery barrier store over `storage/session-recovery/`.
 _Avoid_: projection (the fold's output is the session's state), SessionRuntimeService, SessionManager
 
 ## UI Components

--- a/apps/app/src/features/chat/components/chat-input-composer.tsx
+++ b/apps/app/src/features/chat/components/chat-input-composer.tsx
@@ -1,3 +1,4 @@
+import type { SessionRecoverySnapshot } from "@vibest/contract";
 import {
   PromptInput,
   PromptInputSubmit,
@@ -6,7 +7,7 @@ import {
 } from "@vibest/ui/ai-elements/prompt-input";
 import { Button } from "@vibest/ui/components/button";
 import { Card, CardFrame, CardFrameHeader } from "@vibest/ui/components/card";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { useStore } from "zustand";
 
 import type { OutgoingMessage } from "@/features/chat/runtime/chat-state";
@@ -18,6 +19,51 @@ import { createChatBaseExtensions } from "./input/extensions/chat-base-extension
 import { createSubmitKeymap } from "./input/extensions/keymaps";
 import { useChatInputController } from "./input/use-chat-input-controller";
 import { useChatInputHasContent } from "./input/use-chat-input-has-content";
+
+const recoveryPromptSummary = (prompt: SessionRecoverySnapshot["prompts"][number]): string => {
+  const text: string[] = [];
+  let fileSummary: string | undefined;
+  let targets = 0;
+  for (const part of prompt.parts) {
+    switch (part.type) {
+      case "text":
+        text.push(part.text);
+        break;
+      case "file":
+        fileSummary ??= part.filename ?? part.url;
+        break;
+      case "data-inspector":
+        targets += part.data.length;
+        break;
+    }
+  }
+  const joinedText = text.join(" ").trim();
+  if (joinedText) return joinedText;
+  if (fileSummary) return fileSummary;
+  return targets === 1 ? "1 inspector target" : `${targets} inspector targets`;
+};
+
+function UncertainPromptList({ prompts }: { prompts: SessionRecoverySnapshot["prompts"] }) {
+  return (
+    <ol aria-label="Uncertain prompts" className="w-full space-y-2">
+      {prompts.map((prompt, index) => {
+        const summary = recoveryPromptSummary(prompt);
+        return (
+          <li
+            key={prompt.messageId}
+            data-slot="uncertain-user-message"
+            className="flex min-w-0 items-center gap-3 text-sm"
+          >
+            <span className="min-w-0 flex-1 truncate" title={summary}>
+              {summary}
+            </span>
+            <span className="text-muted-foreground shrink-0 text-xs">Uncertain · {index + 1}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
 
 function QueuedPromptList({
   messages,
@@ -85,10 +131,12 @@ function QueuedPromptList({
 }
 
 export function ChatInputComposer({ toolbar }: { toolbar?: ReactNode }) {
-  const { prompt, steer, turnInProgress, store } = useChatSession();
+  const { acknowledgeRecovery, prompt, steer, turnInProgress, store } = useChatSession();
   const status = useStore(store, (state) => state.session.status);
   const activeTurnId = useStore(store, (state) => state.session.activeTurnId);
   const outgoing = useStore(store, (state) => state.outgoing);
+  const recovery = useStore(store, (state) => state.recovery.snapshot);
+  const [acknowledgementError, setAcknowledgementError] = useState<string | null>(null);
 
   const controller = useChatInputController({
     extensions: (self) => [
@@ -96,6 +144,9 @@ export function ChatInputComposer({ toolbar }: { toolbar?: ReactNode }) {
       createSubmitKeymap({ onSubmit: () => void self.submit() }),
     ],
     onSubmit: (text) => {
+      if (recovery !== null) return false;
+      // The composer clears once the message is accepted into the local queue;
+      // the promise may settle later when this item reaches the server.
       void prompt(text).catch(() => undefined);
       return;
     },
@@ -106,12 +157,46 @@ export function ChatInputComposer({ toolbar }: { toolbar?: ReactNode }) {
 
   return (
     <CardFrame>
-      {outgoing.length > 0 && (
-        <CardFrameHeader className="p-3">
-          <QueuedPromptList messages={outgoing} canSteer={canSteer} onSteer={steer} />
+      {(recovery !== null || outgoing.length > 0) && (
+        <CardFrameHeader className="flex-col items-stretch gap-3 p-3">
+          {recovery !== null && (
+            <div className="flex flex-col gap-2 text-sm" role="status">
+              <p>
+                The server restarted during a possible active turn. The old work was not replayed.
+                Committed history is shown where available.
+              </p>
+              <UncertainPromptList prompts={recovery.prompts} />
+              <Button
+                className="self-start"
+                size="sm"
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setAcknowledgementError(null);
+                  void acknowledgeRecovery(recovery.recoveryId).catch((error: unknown) => {
+                    setAcknowledgementError(
+                      error instanceof Error ? error.message : "Recovery acknowledgement failed",
+                    );
+                  });
+                }}
+              >
+                Acknowledge uncertainty and allow future prompts
+              </Button>
+              {acknowledgementError !== null && (
+                <p className="text-destructive" role="alert">
+                  {acknowledgementError}
+                </p>
+              )}
+            </div>
+          )}
+          {outgoing.length > 0 && (
+            <QueuedPromptList messages={outgoing} canSteer={canSteer} onSteer={steer} />
+          )}
         </CardFrameHeader>
       )}
       <Card
+        aria-disabled={recovery !== null}
+        inert={recovery !== null ? true : undefined}
         render={
           <PromptInput
             onSubmit={(event) => {
@@ -125,7 +210,12 @@ export function ChatInputComposer({ toolbar }: { toolbar?: ReactNode }) {
           <ChatInput />
           <PromptInputToolbar>
             <PromptInputTools>{toolbar}</PromptInputTools>
-            <PromptInputSubmit disabled={!hasContent} status={turnInProgress ? "ready" : status} />
+            <PromptInputSubmit
+              disabled={!hasContent || recovery !== null}
+              // During a turn this button enqueues rather than interrupts, so the
+              // send arrow is the truthful affordance instead of the stop square.
+              status={turnInProgress ? "ready" : status}
+            />
           </PromptInputToolbar>
         </ChatInputProvider>
       </Card>

--- a/apps/app/src/features/chat/components/chat-session-context.ts
+++ b/apps/app/src/features/chat/components/chat-session-context.ts
@@ -19,6 +19,7 @@ export interface ChatSessionValue {
   prompt: (text: string) => Promise<void>;
   /** Marks an existing queued follow-up for delivery into the active turn. */
   steer: (messageId: string) => void;
+  acknowledgeRecovery: (recoveryId: string) => Promise<void>;
   respondToRequest: (requestId: string, response: AgentResponse) => void | Promise<void>;
   /** A turn is producing a reply (submitted / streaming). */
   turnInProgress: boolean;

--- a/apps/app/src/features/chat/components/chat-session-provider.tsx
+++ b/apps/app/src/features/chat/components/chat-session-provider.tsx
@@ -93,6 +93,10 @@ export function ChatSessionProvider({
   );
   const prompt = useCallback((text: string) => chat.prompt(text), [chat]);
   const steer = useCallback((messageId: string) => chat.steer(messageId), [chat]);
+  const acknowledgeRecovery = useCallback(
+    (recoveryId: string) => chat.acknowledgeRecovery(recoveryId),
+    [chat],
+  );
 
   const reasoningEfforts = modelInfo?.reasoningEfforts ?? NO_REASONING_EFFORTS;
   // orderPermissionModes builds a new array on every call, so it is memoised on
@@ -117,6 +121,7 @@ export function ChatSessionProvider({
       store: chat.store,
       prompt,
       steer,
+      acknowledgeRecovery,
       respondToRequest: chat.respondToAgentRequest,
       turnInProgress,
       providers,
@@ -135,6 +140,7 @@ export function ChatSessionProvider({
       chat,
       prompt,
       steer,
+      acknowledgeRecovery,
       turnInProgress,
       providers,
       providerId,

--- a/apps/app/src/features/chat/runtime/chat-history.ts
+++ b/apps/app/src/features/chat/runtime/chat-history.ts
@@ -68,6 +68,7 @@ export function handleHistoryCompleted(
       }
     }
     state.sync.floor = null;
+    state.recovery.historyPending = false;
     recovery.hydrateSnapshot(state, effects, floor.snapshot, true);
     for (const event of floor.events) recovery.applyEvent(state, effects, event);
     startReconcile(state, effects);
@@ -77,6 +78,7 @@ export function handleHistoryCompleted(
   const reconcile = state.sync.reconcile;
   if (!reconcile || reconcile.id !== input.id) return false;
   state.sync.reconcile = null;
+  state.recovery.historyPending = false;
   if (input.error !== undefined) {
     effects.push({
       type: "logError",

--- a/apps/app/src/features/chat/runtime/chat-manager.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-manager.test.ts
@@ -25,6 +25,7 @@ class FakeTransport implements ChatSessionTransport {
   prompt = async () => ({ turnId: "turn-receipt" });
   steer = async () => {};
   getMessages = async () => null;
+  acknowledgeRecovery = async () => undefined;
   respondToAgentRequest = async (_requestId: string, _response: AgentResponse) => {};
   setModel = async (_providerId: string, _modelId: string) => {};
   setReasoningEffort = async (_effort: ReasoningEffort) => {};

--- a/apps/app/src/features/chat/runtime/chat-outgoing.ts
+++ b/apps/app/src/features/chat/runtime/chat-outgoing.ts
@@ -101,6 +101,8 @@ function maybeDispatchFollowUp(state: ChatDraft, effects: ChatEffects): void {
     sendingDelivery(state, "follow-up") !== undefined ||
     !state.sync.historyLoaded ||
     state.sync.floor !== null ||
+    state.recovery.snapshot !== null ||
+    state.recovery.historyPending ||
     !state.prompt.boundaryOpen ||
     nextIndex === -1
   ) {

--- a/apps/app/src/features/chat/runtime/chat-runtime.ts
+++ b/apps/app/src/features/chat/runtime/chat-runtime.ts
@@ -306,6 +306,11 @@ export class ChatRuntime {
     this.#send({ type: "steerRequested", messageId });
   }
 
+  acknowledgeRecovery(recoveryId: string): Promise<void> {
+    const signal = this.#lifetimeController.signal;
+    return raceWithSignal(this.#transport.acknowledgeRecovery(recoveryId, { signal }), signal);
+  }
+
   setModel(providerId: string, modelId: string): Promise<void> {
     const signal = this.#lifetimeController.signal;
     return raceWithSignal(this.#transport.setModel(providerId, modelId, { signal }), signal);

--- a/apps/app/src/features/chat/runtime/chat-session.ts
+++ b/apps/app/src/features/chat/runtime/chat-session.ts
@@ -40,6 +40,42 @@ export function addRequest(state: ChatDraft, effects: ChatEffects, request: Agen
   else state.session.pendingRequests[index] = request;
 }
 
+function exposeRecovery(
+  state: ChatDraft,
+  effects: ChatEffects,
+  recovery: SessionRuntimeSnapshot["recovery"],
+): void {
+  const previousRecoveryId = state.recovery.snapshot?.recoveryId;
+  state.recovery.snapshot = recovery;
+  if (recovery === null) {
+    state.recovery.historyPending = false;
+    return;
+  }
+  state.prompt.boundaryOpen = false;
+  state.session.status = "ready";
+  state.session.pendingRequests = [];
+  if (recovery.recoveryId === previousRecoveryId) return;
+
+  state.recovery.historyPending = true;
+  const submitting = sendingMessage(state);
+  if (submitting) {
+    state.outgoing = state.outgoing.filter(
+      (outgoing) => outgoing.message.id !== submitting.message.id,
+    );
+    removeValue(state.prompt.pendingMessageIds, submitting.message.id);
+    effects.push({
+      type: "rejectPrompt",
+      messageId: submitting.message.id,
+      error: new Error(
+        "The server restarted before this prompt's outcome was known. It was not replayed.",
+      ),
+    });
+  }
+  // The initial floor already reads the authoritative history. Only a recovery
+  // discovered after that floor needs a separate reconcile operation.
+  if (state.sync.historyLoaded && state.sync.floor === null) state.sync.needsReconcile = true;
+}
+
 export function hydrateSnapshot(
   state: ChatDraft,
   effects: ChatEffects,
@@ -47,6 +83,8 @@ export function hydrateSnapshot(
   skipGapCheck: boolean,
 ): void {
   if (!isChatActive(state)) return;
+
+  exposeRecovery(state, effects, snapshot.recovery);
 
   state.session.pendingRequests = [];
   for (const request of snapshot.pendingRequests) addRequest(state, effects, request);
@@ -157,6 +195,11 @@ export function hydrateSnapshot(
         ? snapshot.status.phase
         : null;
   }
+  if (snapshot.recovery !== null) {
+    state.prompt.boundaryOpen = false;
+    state.session.status = "ready";
+    state.session.pendingRequests = [];
+  }
   startReconcile(state, effects);
   maybeDispatchOutgoing(state, effects);
 }
@@ -213,6 +256,14 @@ export function applyEvent(
         state.prompt.pendingMessageIds.length === 0 &&
         (event.phase === "idle" || event.phase === "crashed");
       break;
+    case "session.recovery.acknowledged":
+      if (state.recovery.snapshot?.recoveryId === event.recoveryId) {
+        state.recovery.snapshot = null;
+        state.prompt.boundaryOpen =
+          state.prompt.pendingMessageIds.length === 0 &&
+          (event.phase === "idle" || event.phase === "crashed");
+      }
+      break;
     case "session.crashed":
       state.session.activeTurnId = null;
       state.prompt.pendingMessageIds = [];
@@ -266,6 +317,8 @@ export function applyEvent(
       state.session.pendingRequests = state.session.pendingRequests.filter(
         (request) => request.id !== event.requestId,
       );
+      break;
+    case "session.recovery.acknowledged":
       break;
     case "session.crashed":
       for (const turnId of Object.keys(state.turns.folds)) abandonFold(state, effects, turnId);
@@ -352,6 +405,7 @@ export function handleTransportEvent(
       state.sync.reconcile = null;
       effects.push({ type: "cancelHistory", id: reconcile.id });
     }
+    exposeRecovery(state, effects, event.snapshot.recovery);
     const changedStream = attachStream(state, effects, event.snapshot);
     if (!state.sync.historyLoaded) {
       startHistoryFloor(state, effects, event.snapshot);

--- a/apps/app/src/features/chat/runtime/chat-state.ts
+++ b/apps/app/src/features/chat/runtime/chat-state.ts
@@ -1,6 +1,7 @@
 import type {
   PromptPart,
   SessionPhase,
+  SessionRecoverySnapshot,
   SessionRuntimeSnapshot,
   SessionScopedEvent,
 } from "@vibest/contract";
@@ -51,6 +52,10 @@ export type ChatState = {
     activeTurnId: string | null;
   };
   outgoing: OutgoingMessage[];
+  recovery: {
+    snapshot: SessionRecoverySnapshot | null;
+    historyPending: boolean;
+  };
   lifecycle: {
     session: "available" | "terminated";
     instance: "active" | "disposed";
@@ -91,6 +96,7 @@ export function createChatState(): ChatState {
       activeTurnId: null,
     },
     outgoing: [],
+    recovery: { snapshot: null, historyPending: false },
     lifecycle: { session: "available", instance: "active" },
     sync: {
       streamId: null,
@@ -127,6 +133,7 @@ export function copyChatState(state: ChatState): ChatState {
       pendingRequests: state.session.pendingRequests.slice(),
     },
     outgoing: state.outgoing.slice(),
+    recovery: { ...state.recovery },
     lifecycle: { ...state.lifecycle },
     sync: {
       ...state.sync,
@@ -155,6 +162,7 @@ export const isChatActive = (state: ChatState): boolean =>
 export const statusFromPhase = (phase: SessionPhase): "streaming" | "ready" | "error" => {
   switch (phase) {
     case "idle":
+    case "recovery_required":
       return "ready";
     case "crashed":
       return "error";

--- a/apps/app/src/features/chat/runtime/chat-subscription.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-subscription.test.ts
@@ -11,6 +11,7 @@ const snapshot: SessionRuntimeSnapshot = {
     sessionId: "session-1",
   },
   status: { phase: "idle" },
+  recovery: null,
   activeTurn: null,
   activePrompt: null,
   acceptedPrompt: null,

--- a/apps/app/src/features/chat/runtime/chat-transport-port.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport-port.ts
@@ -86,6 +86,7 @@ export interface ChatSessionTransport {
    * degraded path, not the common one.
    */
   getMessages(options?: ChatTransportCallOptions): Promise<readonly UIMessage[] | null>;
+  acknowledgeRecovery(recoveryId: string, options?: ChatTransportCallOptions): Promise<void>;
   /**
    * Resolves normally when the request is no longer pending — including when
    * another client answered it first (the server's "not pending" is an

--- a/apps/app/src/features/chat/runtime/chat-transport.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport.test.ts
@@ -15,6 +15,7 @@ const snapshot: SessionRuntimeSnapshot = {
   ref,
   streamId: "stream-1",
   status: { phase: "idle" },
+  recovery: null,
   activeTurn: null,
   activePrompt: null,
   acceptedPrompt: null,
@@ -290,6 +291,9 @@ describe("OrpcChatSessionTransport RPC mapping", () => {
           record("getMessages", options);
           return { messages: [] };
         },
+        acknowledgeRecovery: async (_input: unknown, options?: unknown) => {
+          record("acknowledgeRecovery", options);
+        },
         respondToAgentRequest: async (_input: unknown, options?: unknown) => {
           record("respondToAgentRequest", options);
         },
@@ -312,6 +316,7 @@ describe("OrpcChatSessionTransport RPC mapping", () => {
       { signal },
     );
     await transport.getMessages({ signal });
+    await transport.acknowledgeRecovery("recovery-1", { signal });
     await transport.respondToAgentRequest(
       "request-1",
       { type: "tool", behavior: "allow" },
@@ -324,13 +329,14 @@ describe("OrpcChatSessionTransport RPC mapping", () => {
     expect(calls.map((call) => call.name)).toEqual([
       "prompt",
       "getMessages",
+      "acknowledgeRecovery",
       "respondToAgentRequest",
       "setModel",
       "setReasoningEffort",
       "setPermissionMode",
     ]);
     expect(calls.map((call) => call.options)).toEqual(
-      Array.from({ length: 6 }, () => ({ signal })),
+      Array.from({ length: 7 }, () => ({ signal })),
     );
   });
 

--- a/apps/app/src/features/chat/runtime/chat-transport.ts
+++ b/apps/app/src/features/chat/runtime/chat-transport.ts
@@ -36,6 +36,7 @@ type SessionClient = Pick<
   | "getSnapshot"
   | "getMessages"
 > & {
+  acknowledgeRecovery?: VibestSessionClient["acknowledgeRecovery"];
   subscribe: (
     ...args: Parameters<VibestSessionClient["subscribe"]>
   ) => Promise<AsyncIterable<SubscribeStreamEvent>>;
@@ -103,6 +104,15 @@ export class OrpcChatSessionTransport implements ChatSessionTransport {
     options?: ChatTransportCallOptions,
   ): Promise<void> => {
     await this.client.session.steer({ ref: this.#ref, ...input }, options);
+  };
+
+  acknowledgeRecovery = async (
+    recoveryId: string,
+    options?: ChatTransportCallOptions,
+  ): Promise<void> => {
+    const acknowledge = this.client.session.acknowledgeRecovery;
+    if (!acknowledge) throw new Error("Recovery acknowledgement is unavailable");
+    await acknowledge({ ref: this.#ref, recoveryId }, options);
   };
 
   getMessages = async (

--- a/apps/app/src/features/chat/runtime/chat-update.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.test.ts
@@ -15,6 +15,7 @@ const snapshot = (overrides: Partial<SessionRuntimeSnapshot> = {}): SessionRunti
   ref,
   streamId: "stream-1",
   status: { phase: "idle" },
+  recovery: null,
   activeTurn: null,
   activePrompt: null,
   acceptedPrompt: null,

--- a/apps/app/src/features/chat/runtime/chat-update.test.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.test.ts
@@ -125,7 +125,7 @@ describe("updateChat", () => {
     const state: ChatState = {
       ...createChatState(),
       session: { ...createChatState().session, activeTurnId: "turn-1", status: "streaming" },
-      sync: { ...createChatState().sync, historyLoaded: true },
+      sync: { ...createChatState().sync, historyLoaded: true, streamId: "stream-1", cursor: 0 },
       outgoing: [
         {
           message: userMessage("follow", "afterwards"),
@@ -145,6 +145,7 @@ describe("updateChat", () => {
     const transition = updateChat(state, {
       type: "transportEvent",
       event: {
+        streamId: "stream-1",
         seq: 1,
         ref,
         type: "session.message.chunk",
@@ -168,6 +169,7 @@ describe("updateChat", () => {
     const state: ChatState = {
       ...createChatState(),
       session: { ...createChatState().session, activeTurnId: "turn-2", status: "streaming" },
+      sync: { ...createChatState().sync, streamId: "stream-1", cursor: 0 },
       outgoing: [
         {
           message: userMessage("steer", "now"),
@@ -181,6 +183,7 @@ describe("updateChat", () => {
     const stale = updateChat(state, {
       type: "transportEvent",
       event: {
+        streamId: "stream-1",
         seq: 1,
         ref,
         type: "session.message.chunk",

--- a/apps/app/src/features/chat/runtime/chat-update.ts
+++ b/apps/app/src/features/chat/runtime/chat-update.ts
@@ -63,6 +63,21 @@ export function updateChat(state: ChatState, input: ChatInput): ChatTransition {
     return { state: next, effects };
   }
 
+  if (input.type === "promptRequested" && state.recovery.snapshot !== null) {
+    return {
+      state,
+      effects: [
+        {
+          type: "rejectPrompt",
+          messageId: input.message.id,
+          error: new Error(
+            "A server restart left the previous turn uncertain. Acknowledge recovery before sending another prompt.",
+          ),
+        },
+      ],
+    };
+  }
+
   if (input.type === "promptRequested" && !isChatActive(state)) {
     return {
       state,

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -39,6 +39,7 @@ class FakeTransport implements ChatSessionTransport {
   // When set, getMessages blocks on it — for tests that race the history
   // floor against live traffic.
   historyGate: Promise<void> | null = null;
+  historyError: unknown = null;
   getMessagesCalls = 0;
   historySignals: AbortSignal[] = [];
   promptCalls: Array<{ messageId: string; parts: ReadonlyArray<PromptPart> }> = [];
@@ -59,6 +60,8 @@ class FakeTransport implements ChatSessionTransport {
   responseSignals: AbortSignal[] = [];
   responseGate: Promise<void> | null = null;
   configSignals: AbortSignal[] = [];
+  recoveryAcknowledgements: string[] = [];
+  recoveryAcknowledgementError: unknown = null;
 
   subscribe(onEvent: (event: ChatTransportEvent) => void): () => void {
     this.onEvent = onEvent;
@@ -94,13 +97,20 @@ class FakeTransport implements ChatSessionTransport {
     if (this.steerError) throw this.steerError;
   };
 
+  acknowledgeRecovery = async (recoveryId: string, options?: ChatTransportCallOptions) => {
+    this.recoveryAcknowledgements.push(recoveryId);
+    options?.signal?.throwIfAborted();
+    if (this.recoveryAcknowledgementError) throw this.recoveryAcknowledgementError;
+  };
   getMessages = async (options?: ChatTransportCallOptions) => {
     this.getMessagesCalls += 1;
     if (options?.signal) this.historySignals.push(options.signal);
     options?.signal?.throwIfAborted();
     const history = this.history;
     const gate = this.historyGate;
+    const error = this.historyError;
     if (gate) await gate;
+    if (error) throw error;
     return history;
   };
   respondToAgentRequest = async (
@@ -135,6 +145,7 @@ const makeChat = (options?: { onTerminated?: () => void }) => {
       ref,
       streamId: attachedStreamId,
       status: { phase: "idle" },
+      recovery: null,
       activeTurn: null,
       activePrompt: null,
       acceptedPrompt: null,
@@ -255,7 +266,7 @@ describe("Chat hydration", () => {
       cursor: 10,
     });
 
-    expect(chat.store.getState().messages.map((message) => message.id)).toContain(
+    expect(chat.store.getState().session.messages.map((message) => message.id)).toContain(
       "new-stream-prompt",
     );
   });
@@ -277,10 +288,10 @@ describe("Chat hydration", () => {
     });
     live(7, { type: "session.turn.started", turnId: "stale-turn", phase: "running" });
 
-    expect(chat.store.getState().messages.map((message) => message.id)).not.toContain(
+    expect(chat.store.getState().session.messages.map((message) => message.id)).not.toContain(
       "already-past",
     );
-    expect(chat.store.getState().status).toBe("ready");
+    expect(chat.store.getState().session.status).toBe("ready");
   });
 
   it("ignores an old-stream live event after a new attach wins", async () => {
@@ -289,10 +300,10 @@ describe("Chat hydration", () => {
     await attach({ streamId: "stream-2", cursor: 10 });
 
     live(100, { type: "session.turn.started", turnId: "old-turn", phase: "running" }, "stream-1");
-    expect(chat.store.getState().status).toBe("ready");
+    expect(chat.store.getState().session.status).toBe("ready");
 
     live(11, { type: "session.turn.started", turnId: "new-turn", phase: "running" });
-    expect(chat.store.getState().status).toBe("streaming");
+    expect(chat.store.getState().session.status).toBe("streaming");
   });
 
   it("drops buffered old-stream events when a new attach wins during the history floor", async () => {
@@ -466,6 +477,7 @@ describe("Chat hydration", () => {
     const [start, delta] = textChunks("t", "buffered");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [chunkEvent(1, "turn-1", start!), chunkEvent(2, "turn-1", delta!)],
@@ -491,6 +503,7 @@ describe("Chat hydration", () => {
     const [start, delta] = textChunks("t", "once");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [chunkEvent(1, "turn-1", start!), chunkEvent(2, "turn-1", delta!)],
@@ -545,6 +558,7 @@ describe("Chat hydration", () => {
     // running turn. The floor is still in flight.
     await attach({
       status: { phase: "requires_action" },
+      recovery: null,
       activePrompt: {
         messageId: "m2",
         parts: [{ type: "text", text: "hi" }],
@@ -580,6 +594,7 @@ describe("Chat hydration", () => {
     const [start] = textChunks("t2", "");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activePrompt: {
         messageId: "m2",
         parts: [{ type: "text", text: "second" }],
@@ -609,6 +624,7 @@ describe("Chat hydration", () => {
     const [start] = textChunks("t", "");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activePrompt: {
         messageId: "prompt-1",
         parts: [{ type: "text", text: "run it" }],
@@ -952,6 +968,170 @@ describe("Chat steering", () => {
   });
 });
 
+describe("Chat recovery barrier", () => {
+  const recovery = {
+    recoveryId: "recovery-1",
+    reason: "server_restart" as const,
+    prompts: [
+      {
+        messageId: "uncertain-message",
+        parts: [{ type: "text" as const, text: "possibly completed" }],
+      },
+    ],
+  };
+
+  it("publishes recovery before a slow initial history floor and uses that floor once", async () => {
+    const { chat, transport, attach } = makeChat();
+    let releaseHistory: () => void = () => undefined;
+    transport.historyGate = new Promise((resolve) => {
+      releaseHistory = resolve;
+    });
+    transport.history = [];
+
+    await attach({ status: { phase: "recovery_required" }, recovery });
+    expect(chat.store.getState()).toMatchObject({
+      recovery: { snapshot: recovery },
+      session: { historyStatus: "loading" },
+    });
+    expect(transport.getMessagesCalls).toBe(1);
+    await expect(chat.prompt("blocked while history hangs")).rejects.toThrow(
+      "Acknowledge recovery before sending another prompt",
+    );
+
+    releaseHistory();
+    await settle();
+    expect(chat.store.getState()).toMatchObject({
+      recovery: { snapshot: recovery },
+      session: { historyStatus: "settled" },
+    });
+    expect(transport.getMessagesCalls).toBe(1);
+  });
+
+  it("rejects new prompts locally while recovery is unresolved", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.history = [];
+    await attach({ status: { phase: "recovery_required" }, recovery });
+
+    await expect(chat.prompt("must wait")).rejects.toThrow(
+      "Acknowledge recovery before sending another prompt",
+    );
+    expect(transport.promptCalls).toEqual([]);
+    expect(chat.store.getState().outgoing).toEqual([]);
+    expect(chat.store.getState().recovery.snapshot).toEqual(recovery);
+  });
+
+  it("releases a pre-existing queued prompt after failed history recovery and broadcast ack", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    transport.history = [];
+    await attach({
+      status: { phase: "running" },
+      activeTurn: activeTurn({ turnId: "turn-old", chunks: [] }),
+      cursor: 3,
+    });
+    const queued = chat.prompt("future work");
+    expect(transport.promptCalls).toEqual([]);
+    expect(chat.store.getState().outgoing).toHaveLength(1);
+
+    transport.historyError = new Error("history unavailable after restart");
+    await attach({
+      streamId: "stream-2",
+      status: { phase: "recovery_required" },
+      recovery,
+      activeTurn: null,
+      cursor: 0,
+    });
+    expect(chat.store.getState().recovery.snapshot).toEqual(recovery);
+    expect(transport.promptCalls).toEqual([]);
+
+    await chat.acknowledgeRecovery(recovery.recoveryId);
+    expect(transport.recoveryAcknowledgements).toEqual(["recovery-1"]);
+    expect(chat.store.getState().recovery.snapshot).toEqual(recovery);
+    expect(transport.promptCalls).toEqual([]);
+
+    live(1, {
+      type: "session.recovery.acknowledged",
+      recoveryId: recovery.recoveryId,
+      phase: "idle",
+    });
+    await queued;
+    expect(chat.store.getState().recovery.snapshot).toBeNull();
+    expect(transport.promptCalls).toEqual([
+      { messageId: expect.any(String), parts: [{ type: "text", text: "future work" }] },
+    ]);
+  });
+
+  it("keeps queued work paused when recovery is acknowledged during a running turn", async () => {
+    const { chat, transport, attach, live } = makeChat();
+    transport.history = [];
+    await attach({
+      status: { phase: "running" },
+      activeTurn: activeTurn({ turnId: "turn-old", chunks: [] }),
+      cursor: 3,
+    });
+    const queued = chat.prompt("future work");
+
+    await attach({
+      streamId: "stream-2",
+      status: { phase: "recovery_required" },
+      recovery,
+      activeTurn: null,
+      cursor: 0,
+    });
+    live(1, {
+      type: "session.recovery.acknowledged",
+      recoveryId: recovery.recoveryId,
+      phase: "running",
+    });
+    expect(chat.store.getState().recovery.snapshot).toBeNull();
+    expect(transport.promptCalls).toEqual([]);
+
+    live(2, {
+      type: "session.turn.ended",
+      turnId: "turn-current",
+      outcome: "completed",
+      phase: "idle",
+    });
+    await queued;
+    expect(transport.promptCalls).toEqual([
+      { messageId: expect.any(String), parts: [{ type: "text", text: "future work" }] },
+    ]);
+  });
+
+  it("rejects an in-flight local prompt instead of replaying it after restart", async () => {
+    const { chat, transport, attach } = makeChat();
+    transport.history = [];
+    await attach({});
+    let releasePrompt: () => void = () => undefined;
+    transport.promptGate = new Promise((resolve) => {
+      releasePrompt = resolve;
+    });
+    const sending = chat.prompt("uncertain work");
+    const sendingError = sending.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await settle();
+    expect(transport.promptCalls).toHaveLength(1);
+
+    await attach({
+      streamId: "stream-2",
+      status: { phase: "recovery_required" },
+      recovery,
+      activeTurn: null,
+      cursor: 0,
+    });
+    expect(await sendingError).toEqual(
+      expect.objectContaining({ message: expect.stringContaining("It was not replayed") }),
+    );
+    expect(transport.promptCalls).toHaveLength(1);
+    expect(chat.store.getState().outgoing).toEqual([]);
+
+    releasePrompt();
+    await settle();
+    expect(transport.promptCalls).toHaveLength(1);
+  });
+});
+
 describe("Chat prompting", () => {
   it("hydrates every unresolved prompt when multiple candidates are pending", async () => {
     const { chat, attach, live } = makeChat();
@@ -969,6 +1149,7 @@ describe("Chat prompting", () => {
     };
     await attach({
       status: { phase: "idle" },
+      recovery: null,
       activePrompt: pendingB,
       pendingPrompts: [pendingA, pendingB],
       activeTurn: activeTurn({ turnId: "turn-old", chunks: [], complete: true }),
@@ -1217,6 +1398,7 @@ describe("Chat prompting", () => {
     const { chat, transport, attach, live } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-old", chunks: [] }),
       cursor: 3,
     });
@@ -1224,6 +1406,7 @@ describe("Chat prompting", () => {
 
     await attach({
       status: { phase: "idle" },
+      recovery: null,
       activePrompt: {
         messageId: "remote-prompt",
         parts: [{ type: "text", text: "remote next" }],
@@ -1264,6 +1447,7 @@ describe("Chat prompting", () => {
     const { chat, transport, attach, live } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-old", chunks: [] }),
       cursor: 3,
     });
@@ -1271,6 +1455,7 @@ describe("Chat prompting", () => {
 
     await attach({
       status: { phase: "idle" },
+      recovery: null,
       activePrompt: {
         messageId: "remote-prompt",
         parts: [{ type: "text", text: "remote next" }],
@@ -1360,6 +1545,7 @@ describe("Chat prompting", () => {
     const { chat, transport, attach, live } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-old", chunks: [] }),
       cursor: 3,
     });
@@ -1416,6 +1602,7 @@ describe("Chat prompting", () => {
 
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activePrompt: {
         messageId: "remote-pending",
         parts: [{ type: "text", text: "remote" }],
@@ -1463,6 +1650,7 @@ describe("Chat prompting", () => {
     const { chat, transport, attach } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-1", chunks: [] }),
       cursor: 4,
     });
@@ -1482,6 +1670,7 @@ describe("Chat prompting", () => {
     await attach({
       streamId: "stream-2",
       status: { phase: "idle" },
+      recovery: null,
       activeTurn: null,
       cursor: 0,
     });
@@ -1594,7 +1783,13 @@ describe("Chat prompting", () => {
     ).toHaveLength(1);
 
     transport.promptError = null;
-    await attach({ status: { phase: "idle" }, activePrompt: null, activeTurn: null, cursor: 0 });
+    await attach({
+      status: { phase: "idle" },
+      recovery: null,
+      activePrompt: null,
+      activeTurn: null,
+      cursor: 0,
+    });
     await second;
 
     expect(transport.promptCalls).toHaveLength(2);
@@ -1856,6 +2051,7 @@ describe("Chat stream errors", () => {
 
     await attach({
       status: { phase: "idle" },
+      recovery: null,
       activePrompt: {
         messageId: "prompt-1",
         parts: [{ type: "text", text: "go" }],
@@ -1886,6 +2082,7 @@ describe("Chat stream errors", () => {
 
     await attach({
       status: { phase: "idle" },
+      recovery: null,
       activePrompt: {
         messageId: "prompt-new",
         parts: [{ type: "text", text: "try again" }],
@@ -1942,6 +2139,7 @@ describe("Chat stream errors", () => {
     await expect(chat.prompt("fail again")).rejects.toThrow("another old failure");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activePrompt: {
         messageId: "remote-2",
         parts: [{ type: "text", text: "retained" }],
@@ -1974,6 +2172,7 @@ describe("Chat agent requests", () => {
     const { chat, attach, live } = makeChat();
     await attach({
       status: { phase: "requires_action" },
+      recovery: null,
       pendingRequests: [toolRequest],
       cursor: 1,
     });
@@ -2012,6 +2211,7 @@ describe("Chat agent requests", () => {
     const { chat, attach, live } = makeChat();
     await attach({
       status: { phase: "requires_action" },
+      recovery: null,
       pendingRequests: [toolRequest],
       cursor: 1,
     });
@@ -2128,6 +2328,7 @@ describe("Chat truncated buffers", () => {
     const [start, delta] = textChunks("kept", "tail");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [
@@ -2165,6 +2366,7 @@ describe("Chat truncated buffers", () => {
     const [start, delta] = textChunks("t", "seen");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [chunkEvent(1, "turn-1", start!), chunkEvent(2, "turn-1", delta!)],
@@ -2179,6 +2381,7 @@ describe("Chat truncated buffers", () => {
     // gone. Splicing the tail would fabricate a seamless-looking message.
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [chunkEvent(10, "turn-1", { type: "text-delta", id: "t", delta: "LATE" })],
@@ -2206,6 +2409,7 @@ describe("Chat truncated buffers", () => {
     const [start, delta] = textChunks("t", "seen");
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [chunkEvent(1, "turn-1", start!), chunkEvent(2, "turn-1", delta!)],
@@ -2217,6 +2421,7 @@ describe("Chat truncated buffers", () => {
     // Drop + truncation while away flags the turn…
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({
         turnId: "turn-1",
         chunks: [chunkEvent(10, "turn-1", { type: "text-delta", id: "t", delta: "LATE" })],
@@ -2228,7 +2433,7 @@ describe("Chat truncated buffers", () => {
     // …and the next drop straddles the turn's end: the ended event (and its
     // reconcile) never arrives, so the re-attach must recover it.
     transport.history = [userMessage("assistant-1", "whole turn")];
-    await attach({ status: { phase: "idle" }, activeTurn: null, cursor: 12 });
+    await attach({ status: { phase: "idle" }, recovery: null, activeTurn: null, cursor: 12 });
     await settle();
     expect(chat.store.getState().session.messages.map((m) => m.id)).toEqual(["assistant-1"]);
     void live;
@@ -2240,6 +2445,7 @@ describe("Chat lifecycle", () => {
     const { chat, emit, attach, live } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-1", chunks: [] }),
     });
     const queued = chat.prompt("later");
@@ -2309,6 +2515,7 @@ describe("Chat lifecycle", () => {
     const { chat, transport, attach, live } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-1", chunks: [] }),
     });
     live(1, {
@@ -2351,7 +2558,7 @@ describe("Chat lifecycle", () => {
 
     // The terminal state is final: nothing may hydrate or fold over it.
     live(2, { type: "session.turn.started", turnId: "turn-late", phase: "running" });
-    await attach({ status: { phase: "idle" } });
+    await attach({ status: { phase: "idle" }, recovery: null });
     expect(chat.store.getState().session.status).toBe("error");
   });
 
@@ -2433,6 +2640,7 @@ describe("Chat lifecycle", () => {
     const { chat, emit, attach } = makeChat();
     await attach({
       status: { phase: "running" },
+      recovery: null,
       activeTurn: activeTurn({ turnId: "turn-1", chunks: [] }),
     });
     const queued = chat.prompt("never sent");

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -339,7 +339,7 @@ describe("Chat hydration", () => {
     releaseHistory();
     await settle();
 
-    expect(chat.store.getState().pendingRequests.map((request) => request.id)).toEqual([
+    expect(chat.store.getState().session.pendingRequests.map((request) => request.id)).toEqual([
       "new-buffered",
     ]);
   });

--- a/apps/app/src/features/chat/runtime/chat.ts
+++ b/apps/app/src/features/chat/runtime/chat.ts
@@ -31,6 +31,9 @@ export class Chat {
 
   steer = (messageId: string): void => this.#runtime.steer(messageId);
 
+  acknowledgeRecovery = (recoveryId: string): Promise<void> =>
+    this.#runtime.acknowledgeRecovery(recoveryId);
+
   setModel = (providerId: string, modelId: string): Promise<void> =>
     this.#runtime.setModel(providerId, modelId);
 

--- a/docs/adr/0004-recover-interrupted-turns-with-a-barrier.md
+++ b/docs/adr/0004-recover-interrupted-turns-with-a-barrier.md
@@ -1,0 +1,82 @@
+# Recover interrupted turns with a durable acknowledgement barrier
+
+## Context
+
+A server process can stop after a harness accepted a prompt but before Vibest
+observed a terminal turn event. The replacement process has a new session
+stream and can read whatever conversation history the harness committed, but it
+cannot prove whether the old execution stopped before or after running tools.
+
+The current harness `resume` operations restore conversation context for future
+prompts. They do not attach to the same in-flight executor, replay its native
+event cursor, or recover pending permission callbacks. Reissuing the prompt can
+therefore repeat file writes, commands, network calls, or other non-idempotent
+tool effects.
+
+Treating the replacement session as idle is also unsafe: a client-local Queue
+can immediately send its next prompt before committed history is reconciled,
+while the user has no indication that the previous result is unknown.
+
+## Decision
+
+Before a session prompt is published or sent to a harness, Vibest writes a
+separate durable recovery record containing the server boot id and every prompt
+whose turn has not reached a known terminal event. Prompt acceptance correlates
+each prompt with its turn. Terminal and rejection events update or remove only
+the prompts they account for.
+
+On a later server boot, any unresolved record owned by the previous boot becomes
+a **Recovery barrier**:
+
+- snapshots and status report `recovery_required`;
+- committed harness history remains readable;
+- no old prompt is replayed;
+- no queued or newly entered prompt is sent;
+- stale pending requests are not restored as actionable;
+- the user is shown every uncertain prompt and must explicitly acknowledge the
+  unknown outcome before future work may run.
+
+Acknowledgement is compare-and-set by recovery id and is broadcast as a session
+event. It means only that the user reviewed the available history and accepts
+starting future work. It does not assert that the old turn completed, failed,
+was interrupted, or had no side effects.
+
+Recovery records live separately from session identity metadata. This keeps
+runtime checkpoint writes from racing title/archive updates and lets corrupt
+recovery data fail closed without making ordinary metadata unreadable.
+
+## Rejected alternatives
+
+### Automatically replay the prompt
+
+Rejected because the old process may already have executed tools. None of the
+current harnesses provides exactly-once prompt or tool semantics.
+
+### Treat adapter resume as active-turn continuation
+
+Rejected because adapter resume opens the persisted conversation for future
+work; it does not attach to the original running executor or recover its pending
+callbacks.
+
+### Mark every interrupted turn failed and continue the Queue
+
+Rejected because a failure label does not resolve whether side effects occurred,
+and continuing automatically can run dependent prompts against an unknown
+workspace state.
+
+### Persist the old stream id and cursor
+
+Rejected because the old process's event sequence and buffers no longer exist.
+The replacement process must use a new stream generation.
+
+## Consequences
+
+- Server restarts are fail-closed for unresolved turns.
+- Native history may restore some or all committed output, but cannot synthesize
+  a final assistant reply that the harness never persisted.
+- A history read may start a harness context process for adapters without a cold
+  history reader; it still sends no prompt while the barrier exists.
+- Tool side effects that occurred before the crash remain possible and unknown.
+- Actual active-turn continuation remains a future adapter capability requiring
+  attach-only ownership, durable native turn identity, event replay, and pending
+  request recovery.

--- a/packages/contract/src/domain.ts
+++ b/packages/contract/src/domain.ts
@@ -162,6 +162,7 @@ export const SessionPhaseSchema = Schema.Literals([
   "idle",
   "running",
   "requires_action",
+  "recovery_required",
   "crashed",
 ]);
 export type SessionPhase = typeof SessionPhaseSchema.Type;
@@ -192,6 +193,7 @@ export const SessionScopedEventTypes = [
   "session.request.asked",
   "session.request.replied",
   "session.request.rejected",
+  "session.recovery.acknowledged",
   "session.crashed",
 ] as const;
 export type SessionScopedEventType = (typeof SessionScopedEventTypes)[number];
@@ -253,6 +255,10 @@ export type SessionScopedEventBody =
       readonly type: "session.request.rejected";
       readonly requestId: string;
       readonly reason?: string;
+    }
+  | {
+      readonly type: "session.recovery.acknowledged";
+      readonly recoveryId: string;
     }
   | { readonly type: "session.crashed"; readonly reason: string };
 
@@ -486,11 +492,23 @@ export const HarnessProbeOutputSchema = Schema.Struct({
 });
 export type HarnessProbeOutput = typeof HarnessProbeOutputSchema.Type;
 
+export type SessionRecoverySnapshot = {
+  readonly recoveryId: string;
+  readonly reason: "server_restart";
+  readonly prompts: ReadonlyArray<{
+    readonly messageId: string;
+    readonly parts: ReadonlyArray<PromptPart>;
+    readonly turnId?: string;
+  }>;
+};
+
 export type SessionRuntimeSnapshot = {
   readonly ref: SessionRef;
   /** Process-local incarnation whose cursor and retained events this snapshot describes. */
   readonly streamId: string;
   readonly status: SessionStatus;
+  /** Durable uncertainty from an unresolved turn owned by an earlier server boot. */
+  readonly recovery: SessionRecoverySnapshot | null;
   readonly pendingRequests: ReadonlyArray<AgentRequest>;
   readonly activeTurn: ActiveTurnSnapshot | null;
   // Newest prompt to render for reconnect (an unresolved candidate wins).
@@ -565,6 +583,12 @@ export type SteerInput = typeof SteerInputSchema.Type;
 
 export const PromptOutputSchema = Schema.Struct({ turnId: Schema.String });
 export type PromptOutput = typeof PromptOutputSchema.Type;
+
+export const AcknowledgeRecoveryInputSchema = Schema.Struct({
+  ref: SessionRefSchema,
+  recoveryId: Schema.NonEmptyString,
+});
+export type AcknowledgeRecoveryInput = typeof AcknowledgeRecoveryInputSchema.Type;
 
 // ---------------------------------------------------------------------------
 // Session capabilities (unchanged; setModel/config remains out of scope)

--- a/packages/contract/src/session.ts
+++ b/packages/contract/src/session.ts
@@ -1,6 +1,7 @@
 import { eventIterator, oc, type } from "@orpc/contract";
 
 import {
+  AcknowledgeRecoveryInputSchema,
   ArchiveSessionInputSchema,
   CreateSessionInputSchema,
   serverErrors,
@@ -61,6 +62,7 @@ export const sessionContract = {
     .input(toStandardSchema(PromptInputSchema))
     .output(toStandardSchema(PromptOutputSchema)),
   steer: base.input(toStandardSchema(SteerInputSchema)),
+  acknowledgeRecovery: base.input(toStandardSchema(AcknowledgeRecoveryInputSchema)),
   interrupt: base.input(toStandardSchema(RefInputSchema)),
   // Session-scoped config, changed via dedicated calls — never on a prompt turn.
   setModel: base.input(toStandardSchema(SetSessionModelInputSchema)),

--- a/packages/server/src/config/paths.ts
+++ b/packages/server/src/config/paths.ts
@@ -18,6 +18,8 @@ export class Paths extends Context.Service<
     readonly sessionsDir: string;
     /** `$VIBEST_HOME/logs` — process log and daemon stdio. */
     readonly logsDir: string;
+    /** `storage/session-recovery/` — durable unresolved-turn barriers. */
+    readonly sessionRecoveryDir: string;
   }
 >()("Paths") {}
 
@@ -33,6 +35,7 @@ const resolve = (home: string) => ({
   projectsFile: path.join(home, "storage", "projects.json"),
   sessionsDir: path.join(home, "storage", "sessions"),
   logsDir: logsDirectory(home),
+  sessionRecoveryDir: path.join(home, "storage", "session-recovery"),
 });
 
 /**

--- a/packages/server/src/harness/errors.ts
+++ b/packages/server/src/harness/errors.ts
@@ -92,6 +92,24 @@ export class SessionClosed extends Schema.TaggedError<SessionClosed>()("SessionC
   }
 }
 
+export class RecoveryRequired extends Schema.TaggedError<RecoveryRequired>()("RecoveryRequired", {
+  sessionId: Schema.String,
+  recoveryId: Schema.String,
+}) {
+  override get message() {
+    return `Session '${this.sessionId}' requires acknowledgement of recovery '${this.recoveryId}'.`;
+  }
+}
+
+export class StaleRecovery extends Schema.TaggedError<StaleRecovery>()("StaleRecovery", {
+  sessionId: Schema.String,
+  recoveryId: Schema.String,
+}) {
+  override get message() {
+    return `Recovery '${this.recoveryId}' is no longer pending for session '${this.sessionId}'.`;
+  }
+}
+
 export class TurnAlreadyRunning extends Schema.TaggedError<TurnAlreadyRunning>()(
   "TurnAlreadyRunning",
   {

--- a/packages/server/src/harness/session-fold.ts
+++ b/packages/server/src/harness/session-fold.ts
@@ -283,6 +283,8 @@ export const foldSessionEvent = (
         pendingRequests.size > 0 ? "requires_action" : current.activeTurn ? "running" : "idle";
       return { ...base, phase, pendingRequests };
     }
+    case "session.recovery.acknowledged":
+      return base;
     case "session.crashed":
       return {
         ...base,
@@ -311,6 +313,7 @@ export const toSnapshot = (
   ref,
   streamId,
   status: toStatus(state),
+  recovery: null,
   pendingRequests: [...state.pendingRequests.values()],
   activeTurn: state.activeTurn
     ? {

--- a/packages/server/src/harness/session-manager.ts
+++ b/packages/server/src/harness/session-manager.ts
@@ -38,6 +38,7 @@ import {
 } from "./session";
 import { initialSessionState, toSnapshot, toStatus } from "./session-fold";
 import type { ResumeManagedSessionInput, SessionConfig } from "./session-io";
+import { SessionRecoveryStore } from "./session-recovery";
 
 /**
  * The sole owner of live session state: one {@link HarnessAgentSessionShape}
@@ -447,6 +448,11 @@ export const HarnessAgentSessionManagerLayer = Layer.effect(
   Effect.gen(function* () {
     const registry = yield* HarnessAgentRegistry;
     const bus = yield* EventBus;
-    return yield* makeHarnessAgentSessionManager(registry, bus);
+    const recovery = yield* SessionRecoveryStore;
+    return yield* makeHarnessAgentSessionManager(registry, bus, (ref, streamId, eventBus) =>
+      makeHarnessAgentSession(ref, streamId, eventBus, (eventRef, body) =>
+        recovery.beforePublish(eventRef, body).pipe(Effect.orDie),
+      ),
+    );
   }),
 );

--- a/packages/server/src/harness/session-recovery.ts
+++ b/packages/server/src/harness/session-recovery.ts
@@ -1,0 +1,279 @@
+import {
+  type PromptPart,
+  PromptPartSchema,
+  type SessionRecoverySnapshot,
+  type SessionRef,
+  type SessionScopedEventBody,
+} from "@vibest/contract";
+import { type JsonStoreLoadError, makeJsonCollection } from "@vibest/effect-json-store";
+import { Context, Crypto, Effect, FileSystem, Layer, Option, Schema, Semaphore } from "effect";
+
+import { Paths } from "../config/paths";
+import { StoreReadError, StoreWriteError } from "../errors";
+import { RecoveryRequired, StaleRecovery } from "./errors";
+
+const RecoveryPromptSchema = Schema.Struct({
+  messageId: Schema.String,
+  parts: Schema.Array(PromptPartSchema),
+  turnId: Schema.optionalKey(Schema.String),
+});
+
+const RecoveryRecordSchema = Schema.Struct({
+  recoveryId: Schema.String,
+  bootId: Schema.String,
+  ref: Schema.Struct({
+    projectId: Schema.String,
+    harnessAgentId: Schema.Literals(["claude-code", "codex", "pi"]),
+    sessionId: Schema.String,
+  }),
+  prompts: Schema.Array(RecoveryPromptSchema),
+  endedTurnIds: Schema.Array(Schema.String),
+});
+
+type RecoveryPrompt = {
+  readonly messageId: string;
+  readonly parts: ReadonlyArray<PromptPart>;
+  readonly turnId?: string;
+};
+
+export type SessionRecoveryRecord = {
+  readonly recoveryId: string;
+  readonly bootId: string;
+  readonly ref: SessionRef;
+  readonly prompts: ReadonlyArray<RecoveryPrompt>;
+  readonly endedTurnIds: ReadonlyArray<string>;
+};
+
+export type SessionRecoveryStoreShape = {
+  readonly bootId: string;
+  readonly read: (ref: SessionRef) => Effect.Effect<SessionRecoveryRecord | null, StoreReadError>;
+  readonly barrier: (
+    ref: SessionRef,
+  ) => Effect.Effect<SessionRecoverySnapshot | null, StoreReadError>;
+  readonly requireClear: (
+    ref: SessionRef,
+  ) => Effect.Effect<void, StoreReadError | RecoveryRequired>;
+  readonly beforePublish: (
+    ref: SessionRef,
+    body: SessionScopedEventBody,
+  ) => Effect.Effect<void, StoreReadError | StoreWriteError | RecoveryRequired>;
+  readonly acknowledge: (
+    ref: SessionRef,
+    recoveryId: string,
+  ) => Effect.Effect<void, StoreReadError | StoreWriteError | StaleRecovery>;
+  readonly clear: (ref: SessionRef) => Effect.Effect<void, StoreWriteError>;
+};
+
+export class SessionRecoveryStore extends Context.Service<
+  SessionRecoveryStore,
+  SessionRecoveryStoreShape
+>()("SessionRecoveryStore") {}
+
+const encodeKeySegment = (prefix: string, value: string): string =>
+  `${prefix}-${encodeURIComponent(value)}`;
+const keyOf = (ref: SessionRef): string =>
+  [
+    encodeKeySegment("project", ref.projectId),
+    encodeKeySegment("harness", ref.harnessAgentId),
+    encodeKeySegment("session", ref.sessionId),
+  ].join("/");
+
+const snapshotOf = (record: SessionRecoveryRecord): SessionRecoverySnapshot => ({
+  recoveryId: record.recoveryId,
+  reason: "server_restart",
+  prompts: record.prompts,
+});
+
+const MAX_ENDED_TURN_IDS = 32;
+const appendEndedTurnId = (endedTurnIds: ReadonlyArray<string>, turnId: string): string[] => {
+  if (endedTurnIds.includes(turnId)) return Array.from(endedTurnIds);
+  return [...endedTurnIds, turnId].slice(-MAX_ENDED_TURN_IDS);
+};
+
+export const makeSessionRecoveryStore = (
+  directory: string,
+  bootId: string,
+  newRecoveryId: Effect.Effect<string>,
+): Effect.Effect<SessionRecoveryStoreShape, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const records = yield* makeJsonCollection({
+      dir: directory,
+      schema: RecoveryRecordSchema,
+      legacy: { schema: RecoveryRecordSchema, migrate: (record) => record },
+    });
+    // A read followed by put/remove is one logical update. The collection
+    // serializes individual operations; this lock keeps the compound update
+    // atomic within the one process that owns this store instance.
+    const lock = Semaphore.makeUnsafe(1);
+    const asReadError = (error: JsonStoreLoadError) =>
+      new StoreReadError({ file: error.file, cause: error });
+    const asWriteError = (error: { readonly file: string }) =>
+      new StoreWriteError({ file: error.file, cause: error });
+
+    const read = (ref: SessionRef) =>
+      records.get(keyOf(ref)).pipe(
+        Effect.mapError(asReadError),
+        Effect.map((found) => (Option.isSome(found) ? found.value : null)),
+      );
+    const put = (record: SessionRecoveryRecord) =>
+      records.put(keyOf(record.ref), record).pipe(Effect.mapError(asWriteError));
+    const removeUnlocked = (ref: SessionRef) =>
+      records.remove(keyOf(ref)).pipe(Effect.mapError(asWriteError));
+    const clear = (ref: SessionRef) => lock.withPermit(removeUnlocked(ref));
+
+    const modify = <E>(
+      ref: SessionRef,
+      change: (
+        current: SessionRecoveryRecord | null,
+      ) => Effect.Effect<SessionRecoveryRecord | null, E>,
+    ): Effect.Effect<void, StoreReadError | StoreWriteError | E> =>
+      lock.withPermit(
+        read(ref).pipe(
+          Effect.flatMap(change),
+          Effect.flatMap((next) => (next === null ? removeUnlocked(ref) : put(next))),
+        ),
+      );
+
+    const beforePublish: SessionRecoveryStoreShape["beforePublish"] = (ref, body) => {
+      switch (body.type) {
+        case "session.prompt.submitted":
+          return modify(ref, (current) => {
+            if (current !== null && current.bootId !== bootId) {
+              return Effect.fail(
+                new RecoveryRequired({
+                  sessionId: ref.sessionId,
+                  recoveryId: current.recoveryId,
+                }),
+              );
+            }
+            const existing = current?.prompts.some((prompt) => prompt.messageId === body.messageId);
+            if (current !== null) {
+              return Effect.succeed(
+                existing
+                  ? current
+                  : {
+                      ...current,
+                      prompts: [
+                        ...current.prompts,
+                        { messageId: body.messageId, parts: body.parts },
+                      ],
+                    },
+              );
+            }
+            return newRecoveryId.pipe(
+              Effect.map(
+                (recoveryId): SessionRecoveryRecord => ({
+                  recoveryId,
+                  bootId,
+                  ref,
+                  prompts: [{ messageId: body.messageId, parts: body.parts }],
+                  endedTurnIds: [],
+                }),
+              ),
+            );
+          });
+        case "session.prompt.accepted":
+          return modify(ref, (current) => {
+            if (current === null || current.bootId !== bootId) return Effect.succeed(current);
+            const prompt = current.prompts.find(
+              (candidate) => candidate.messageId === body.messageId,
+            );
+            if (prompt === undefined) return Effect.succeed(current);
+            if (current.endedTurnIds.includes(body.turnId)) {
+              const prompts = current.prompts.filter(
+                (candidate) => candidate.messageId !== body.messageId,
+              );
+              return Effect.succeed(prompts.length === 0 ? null : { ...current, prompts });
+            }
+            return Effect.succeed({
+              ...current,
+              prompts: current.prompts.map((candidate) =>
+                candidate.messageId === body.messageId
+                  ? { ...candidate, turnId: body.turnId }
+                  : candidate,
+              ),
+            });
+          });
+        case "session.prompt.rejected":
+          return modify(ref, (current) => {
+            if (current === null || current.bootId !== bootId) return Effect.succeed(current);
+            const prompts = current.prompts.filter((prompt) => prompt.messageId !== body.messageId);
+            return Effect.succeed(prompts.length === 0 ? null : { ...current, prompts });
+          });
+        case "session.turn.ended":
+          return modify(ref, (current) => {
+            if (current === null || current.bootId !== bootId) return Effect.succeed(current);
+            const prompts = current.prompts.filter((prompt) => prompt.turnId !== body.turnId);
+            if (prompts.length === 0) return Effect.succeed(null);
+            return Effect.succeed({
+              ...current,
+              prompts,
+              endedTurnIds: appendEndedTurnId(current.endedTurnIds, body.turnId),
+            });
+          });
+        case "session.crashed":
+          return modify(ref, (current) =>
+            current?.bootId === bootId ? Effect.succeed(null) : Effect.succeed(current),
+          );
+        default:
+          return Effect.void;
+      }
+    };
+
+    return {
+      bootId,
+      read,
+      barrier: (ref) =>
+        read(ref).pipe(
+          Effect.map((record) =>
+            record !== null && record.bootId !== bootId ? snapshotOf(record) : null,
+          ),
+        ),
+      requireClear: (ref) =>
+        read(ref).pipe(
+          Effect.flatMap((record) =>
+            record !== null && record.bootId !== bootId
+              ? Effect.fail(
+                  new RecoveryRequired({
+                    sessionId: ref.sessionId,
+                    recoveryId: record.recoveryId,
+                  }),
+                )
+              : Effect.void,
+          ),
+        ),
+      beforePublish,
+      acknowledge: (ref, recoveryId) =>
+        lock.withPermit(
+          Effect.gen(function* () {
+            const record = yield* read(ref);
+            if (record === null || record.bootId === bootId || record.recoveryId !== recoveryId) {
+              return yield* Effect.fail(
+                new StaleRecovery({ sessionId: ref.sessionId, recoveryId }),
+              );
+            }
+            yield* removeUnlocked(ref);
+          }),
+        ),
+      clear,
+    } satisfies SessionRecoveryStoreShape;
+  });
+
+export const SessionRecoveryStoreLayer: Layer.Layer<
+  SessionRecoveryStore,
+  never,
+  Paths | Crypto.Crypto | FileSystem.FileSystem
+> = Layer.effect(
+  SessionRecoveryStore,
+  Effect.gen(function* () {
+    const paths = yield* Paths;
+    const crypto = yield* Crypto.Crypto;
+    const randomId = crypto.randomUUIDv4.pipe(
+      Effect.catchTag("PlatformError", (cause) =>
+        Effect.die(new Error("invariant: platform RNG failed minting a recovery id", { cause })),
+      ),
+    );
+    const bootId = yield* randomId;
+    return yield* makeSessionRecoveryStore(paths.sessionRecoveryDir, bootId, randomId);
+  }),
+);

--- a/packages/server/src/harness/session-recovery.ts
+++ b/packages/server/src/harness/session-recovery.ts
@@ -1,6 +1,7 @@
 import {
   type PromptPart,
   PromptPartSchema,
+  HarnessAgentIdSchema,
   type SessionRecoverySnapshot,
   type SessionRef,
   type SessionScopedEventBody,
@@ -23,7 +24,7 @@ const RecoveryRecordSchema = Schema.Struct({
   bootId: Schema.String,
   ref: Schema.Struct({
     projectId: Schema.String,
-    harnessAgentId: Schema.Literals(["claude-code", "codex", "pi"]),
+    harnessAgentId: HarnessAgentIdSchema,
     sessionId: Schema.String,
   }),
   prompts: Schema.Array(RecoveryPromptSchema),

--- a/packages/server/src/harness/session-service.ts
+++ b/packages/server/src/harness/session-service.ts
@@ -11,7 +11,7 @@ import type {
   SessionSummary,
 } from "@vibest/contract";
 import type { UIMessage } from "ai";
-import { Context, Crypto, Effect, FileSystem, Layer } from "effect";
+import { Context, Crypto, Effect, FileSystem, Layer, Semaphore } from "effect";
 
 import { Paths } from "../config/paths";
 import {
@@ -30,8 +30,10 @@ import type {
   CreateSessionError,
   HarnessAgentNotFound,
   HarnessSessionNotFound,
+  RecoveryRequired,
   ResumeSessionError,
   SessionClosed,
+  StaleRecovery,
   TurnAlreadyRunning,
 } from "./errors";
 import {
@@ -45,6 +47,7 @@ import { HarnessAgentRegistry } from "./registry";
 import type { SessionConfig } from "./session-io";
 import type { HarnessAgentSessionManagerShape } from "./session-manager";
 import { HarnessAgentSessionManager } from "./session-manager";
+import { SessionRecoveryStore, type SessionRecoveryStoreShape } from "./session-recovery";
 import {
   type HarnessAgentSessionRepositoryShape,
   makeHarnessAgentSessionRepository,
@@ -178,7 +181,15 @@ export type HarnessAgentSessionServiceShape = {
     | ResumeSessionError
     | SessionClosed
     | TurnAlreadyRunning
+    | RecoveryRequired
     | AgentOperationError
+  >;
+  readonly acknowledgeRecovery: (
+    ref: SessionRef,
+    recoveryId: string,
+  ) => Effect.Effect<
+    void,
+    SessionNotFound | SessionRefMismatch | StoreReadError | StoreWriteError | StaleRecovery
   >;
   /**
    * Stop the active turn. A session with nothing running succeeds without
@@ -285,8 +296,8 @@ export type HarnessAgentSessionServiceShape = {
    * memory reads as idle, so attaching after a restart neither fails nor
    * starts anything.
    */
-  readonly getStatus: (ref: SessionRef) => Effect.Effect<SessionStatus>;
-  readonly getSnapshot: (ref: SessionRef) => Effect.Effect<SessionRuntimeSnapshot>;
+  readonly getStatus: (ref: SessionRef) => Effect.Effect<SessionStatus, StoreReadError>;
+  readonly getSnapshot: (ref: SessionRef) => Effect.Effect<SessionRuntimeSnapshot, StoreReadError>;
   /** Reverse a bare sessionId back into its full SessionRef. */
   readonly resolveRef: (
     sessionId: string,
@@ -303,10 +314,26 @@ export const makeHarnessAgentSessionService = (deps: {
   readonly registry: HarnessAgentRegistryShape;
   readonly repo: HarnessAgentSessionRepositoryShape;
   readonly bus: EventBusShape;
+  readonly recovery: SessionRecoveryStoreShape;
   /** Mints a session id; RNG failure is a defect, so the effect never fails. */
   readonly newSessionId: Effect.Effect<string>;
 }): HarnessAgentSessionServiceShape => {
-  const { manager, registry, repo, bus, newSessionId } = deps;
+  const { manager, registry, repo, bus, recovery, newSessionId } = deps;
+  const lifecycleLocks = new Map<string, ReturnType<typeof Semaphore.makeUnsafe>>();
+  const lifecycleKey = (ref: SessionRef) =>
+    JSON.stringify([ref.projectId, ref.harnessAgentId, ref.sessionId]);
+  const withLifecycleWrite = <A, E, R>(
+    ref: SessionRef,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const key = lifecycleKey(ref);
+    let lock = lifecycleLocks.get(key);
+    if (lock === undefined) {
+      lock = Semaphore.makeUnsafe(1);
+      lifecycleLocks.set(key, lock);
+    }
+    return lock.withPermit(effect);
+  };
 
   // The permission mode is our closed vocabulary, so membership in the
   // harness's declared subset is checked here — the boundary between the
@@ -469,17 +496,25 @@ export const makeHarnessAgentSessionService = (deps: {
       ),
 
     close: (ref) =>
-      resolveHarnessSessionId(ref).pipe(
-        Effect.andThen(manager.close(ref)),
-        Effect.andThen(bus.closeSession(ref, "session_closed")),
+      withLifecycleWrite(
+        ref,
+        resolveHarnessSessionId(ref).pipe(
+          Effect.andThen(manager.close(ref)),
+          Effect.andThen(recovery.clear(ref).pipe(Effect.orDie)),
+          Effect.andThen(bus.closeSession(ref, "session_closed")),
+        ),
       ),
 
     delete: (ref) =>
-      readChecked(ref).pipe(
-        Effect.andThen(manager.close(ref)),
-        Effect.andThen(bus.closeSession(ref, "session_deleted")),
-        Effect.andThen(repo.remove(ref.projectId, ref.sessionId)),
-        Effect.andThen(bus.publish({ ref, type: "session.deleted" })),
+      withLifecycleWrite(
+        ref,
+        readChecked(ref).pipe(
+          Effect.andThen(manager.close(ref)),
+          Effect.andThen(bus.closeSession(ref, "session_deleted")),
+          Effect.andThen(recovery.clear(ref)),
+          Effect.andThen(repo.remove(ref.projectId, ref.sessionId)),
+          Effect.andThen(bus.publish({ ref, type: "session.deleted" })),
+        ),
       ),
 
     rename: (ref, title) =>
@@ -494,20 +529,28 @@ export const makeHarnessAgentSessionService = (deps: {
       ),
 
     archive: (ref, archived) =>
-      readChecked(ref).pipe(
-        Effect.flatMap((metadata) => {
-          const changed = (metadata.archived ?? false) !== archived;
-          const persist = changed ? repo.write({ ...metadata, archived }) : Effect.void;
-          // Archive is also a lifecycle boundary: persist first so a failed
-          // metadata write never kills live work. Restore stays cold until open.
-          const close = archived
-            ? manager.close(ref).pipe(Effect.andThen(bus.closeSession(ref, "session_closed")))
-            : Effect.void;
-          const publish = changed
-            ? bus.publish({ ref, type: "session.archived", archived })
-            : Effect.void;
-          return persist.pipe(Effect.andThen(close), Effect.andThen(publish));
-        }),
+      withLifecycleWrite(
+        ref,
+        readChecked(ref).pipe(
+          Effect.flatMap((metadata) => {
+            const changed = (metadata.archived ?? false) !== archived;
+            const persist = changed ? repo.write({ ...metadata, archived }) : Effect.void;
+            // Archive is also a lifecycle boundary: persist first so a failed
+            // metadata write never kills live work. Restore stays cold until open.
+            const close = archived
+              ? manager
+                  .close(ref)
+                  .pipe(
+                    Effect.andThen(bus.closeSession(ref, "session_closed")),
+                    Effect.andThen(recovery.clear(ref)),
+                  )
+              : Effect.void;
+            const publish = changed
+              ? bus.publish({ ref, type: "session.archived", archived })
+              : Effect.void;
+            return persist.pipe(Effect.andThen(close), Effect.andThen(publish));
+          }),
+        ),
       ),
 
     // A pure read of our own records — display data is self-owned (title from
@@ -581,64 +624,86 @@ export const makeHarnessAgentSessionService = (deps: {
       ),
 
     prompt: (input) =>
-      Effect.gen(function* () {
-        const metadata = yield* readChecked(input.ref);
-        const userInput = yield* toUserInput(input.parts);
-        // The first prompt names the session before it reaches the harness.
-        yield* stampTitleFromFirstPrompt(metadata, input.parts);
-        const messageId = input.messageId ?? (yield* newSessionId);
+      withLifecycleWrite(
+        input.ref,
+        Effect.gen(function* () {
+          const metadata = yield* readChecked(input.ref);
+          yield* recovery.requireClear(input.ref);
+          const userInput = yield* toUserInput(input.parts);
+          // The first prompt names the session before it reaches the harness.
+          yield* stampTitleFromFirstPrompt(metadata, input.parts);
+          const messageId = input.messageId ?? (yield* newSessionId);
 
-        // Broadcast the received prompt *before* the harness call so it always
-        // precedes the turn's own events in seq order. If the harness then
-        // rejects the prompt, `session.prompt.rejected` compensates — clients
-        // drop the phantom user message and the runtime clears the retained
-        // activePrompt.
-        // A user message is the one thing that justifies starting an agent, so
-        // this is where a runtime is acquired if the session has none — after
-        // the submitted event, so a failed acquisition is compensated by the
-        // same `prompt.rejected` that a harness-side rejection uses.
-        return yield* Effect.uninterruptible(
-          manager
-            .emit(input.ref, {
-              type: "session.prompt.submitted",
-              messageId,
-              parts: input.parts,
-            })
-            .pipe(
-              Effect.andThen(
-                manager.ensureRuntime(
-                  {
-                    sessionId: metadata.harnessSessionId,
-                    harnessAgentId: input.ref.harnessAgentId,
-                    ...(metadata.cwd !== undefined ? { cwd: metadata.cwd } : {}),
-                  },
-                  input.ref,
+          // Broadcast the received prompt *before* the harness call so it always
+          // precedes the turn's own events in seq order. If the harness then
+          // rejects the prompt, `session.prompt.rejected` compensates — clients
+          // drop the phantom user message and the runtime clears the retained
+          // activePrompt.
+          // A user message is the one thing that justifies starting an agent, so
+          // this is where a runtime is acquired if the session has none — after
+          // the submitted event, so a failed acquisition is compensated by the
+          // same `prompt.rejected` that a harness-side rejection uses.
+          return yield* Effect.uninterruptible(
+            manager
+              .emit(input.ref, {
+                type: "session.prompt.submitted",
+                messageId,
+                parts: input.parts,
+              })
+              .pipe(
+                Effect.andThen(
+                  manager.ensureRuntime(
+                    {
+                      sessionId: metadata.harnessSessionId,
+                      harnessAgentId: input.ref.harnessAgentId,
+                      ...(metadata.cwd !== undefined ? { cwd: metadata.cwd } : {}),
+                    },
+                    input.ref,
+                  ),
+                ),
+                Effect.flatMap((runtime) => runtime.prompt(userInput)),
+                // Acquisition and prompt rejection are the same visible outcome:
+                // both must compensate the submitted candidate retained above.
+                Effect.tapError((promptError) =>
+                  manager.emit(input.ref, {
+                    type: "session.prompt.rejected",
+                    messageId,
+                    reason: promptError.message,
+                  }),
+                ),
+                // Once submitted is visible, interruption must not leave the
+                // candidate without a terminal correlation. Runtime prompt
+                // receipts are short-lived; finish this emit before honoring a
+                // disconnected caller's cancellation.
+                Effect.tap((receipt) =>
+                  manager.emit(input.ref, {
+                    type: "session.prompt.accepted",
+                    messageId,
+                    turnId: receipt.turnId,
+                  }),
                 ),
               ),
-              Effect.flatMap((runtime) => runtime.prompt(userInput)),
-              // Acquisition and prompt rejection are the same visible outcome:
-              // both must compensate the submitted candidate retained above.
-              Effect.tapError((promptError) =>
-                manager.emit(input.ref, {
-                  type: "session.prompt.rejected",
-                  messageId,
-                  reason: promptError.message,
-                }),
-              ),
-              // Once submitted is visible, interruption must not leave the
-              // candidate without a terminal correlation. Runtime prompt
-              // receipts are short-lived; finish this emit before honoring a
-              // disconnected caller's cancellation.
-              Effect.tap((receipt) =>
-                manager.emit(input.ref, {
-                  type: "session.prompt.accepted",
-                  messageId,
-                  turnId: receipt.turnId,
-                }),
-              ),
+          );
+        }),
+      ),
+
+    acknowledgeRecovery: (ref, recoveryId) =>
+      withLifecycleWrite(
+        ref,
+        readChecked(ref).pipe(
+          Effect.andThen(
+            Effect.uninterruptible(
+              recovery
+                .acknowledge(ref, recoveryId)
+                .pipe(
+                  Effect.andThen(
+                    manager.emit(ref, { type: "session.recovery.acknowledged", recoveryId }),
+                  ),
+                ),
             ),
-        );
-      }),
+          ),
+        ),
+      ),
 
     steer: (input) =>
       Effect.gen(function* () {
@@ -734,8 +799,26 @@ export const makeHarnessAgentSessionService = (deps: {
         ),
       ),
 
-    getStatus: (ref) => manager.status(ref),
-    getSnapshot: (ref) => manager.snapshot(ref),
+    getStatus: (ref) =>
+      Effect.all([manager.status(ref), recovery.barrier(ref)]).pipe(
+        Effect.map(([status, barrier]) =>
+          barrier === null ? status : { phase: "recovery_required" as const },
+        ),
+      ),
+    getSnapshot: (ref) =>
+      Effect.all([manager.snapshot(ref), recovery.barrier(ref)]).pipe(
+        Effect.map(([snapshot, barrier]) =>
+          barrier === null
+            ? snapshot
+            : {
+                ...snapshot,
+                status: { phase: "recovery_required" as const },
+                recovery: barrier,
+                pendingRequests: [],
+                activeTurn: null,
+              },
+        ),
+      ),
 
     resolveRef: (sessionId) =>
       repo.findBySessionId(sessionId).pipe(
@@ -756,6 +839,7 @@ export const HarnessAgentSessionServiceLayer: Layer.Layer<
   | HarnessAgentSessionManager
   | HarnessAgentRegistry
   | EventBus
+  | SessionRecoveryStore
   | Paths
   | Crypto.Crypto
   | FileSystem.FileSystem
@@ -765,6 +849,7 @@ export const HarnessAgentSessionServiceLayer: Layer.Layer<
     const manager = yield* HarnessAgentSessionManager;
     const registry = yield* HarnessAgentRegistry;
     const bus = yield* EventBus;
+    const recovery = yield* SessionRecoveryStore;
     const paths = yield* Paths;
     const crypto = yield* Crypto.Crypto;
     const repo = yield* makeHarnessAgentSessionRepository(paths.sessionsDir);
@@ -773,6 +858,7 @@ export const HarnessAgentSessionServiceLayer: Layer.Layer<
       registry,
       repo,
       bus,
+      recovery,
       // A platform RNG that cannot produce a uuid is a defect, not a domain
       // failure — keep it out of the service's error channel. Tag-specific so
       // a future recoverable error on this channel stays typed instead of dying.

--- a/packages/server/src/harness/session.ts
+++ b/packages/server/src/harness/session.ts
@@ -208,6 +208,8 @@ export const makeHarnessAgentSession = (
   ref: SessionRef,
   streamId: string,
   bus: EventBusShape,
+  beforePublish: (ref: SessionRef, body: SessionScopedEventBody) => Effect.Effect<void> = () =>
+    Effect.void,
 ): Effect.Effect<HarnessAgentSessionShape, never, Scope.Scope> =>
   Effect.gen(function* () {
     const ownerScope = yield* Scope.Scope;
@@ -270,7 +272,8 @@ export const makeHarnessAgentSession = (
               // event types. (The buffered chunk copy inside `next` keeps the
               // un-stamped draft — snapshot replays read phase from the
               // snapshot's own status.)
-              return Ref.set(state, next).pipe(
+              return beforePublish(ref, wireBody).pipe(
+                Effect.andThen(Ref.set(state, next)),
                 Effect.andThen(bus.publish({ ...event, phase: next.phase })),
                 Effect.andThen(logTurn(wireBody, event.seq)),
               );

--- a/packages/server/src/rpc/runtime.ts
+++ b/packages/server/src/rpc/runtime.ts
@@ -25,6 +25,7 @@ import {
 import { makeCodexAdapter, makeCodexAgent, type CodexAgent } from "../harness/codex";
 import { makeGrokAdapter, makeGrokAgent, type GrokAgent } from "../harness/grok";
 import { makePiAdapter, makePiAgent, type PiAgent } from "../harness/pi";
+import { SessionRecoveryStoreLayer } from "../harness/session-recovery";
 import { ProjectRepositoryLayer, ProjectServiceLayer } from "../project";
 import { NodePtySpawnerLayer, PtyManagerLayer, PtyServiceLayer } from "../pty";
 
@@ -126,15 +127,21 @@ const HarnessProbeProvided = HarnessProbeLayer.pipe(Layer.provide(RegistryLayer)
 // layers by reference, so publish (manager/service) and subscribe (RPC) share
 // the single bus instance. A second reference (or Layer.fresh) would split the
 // bus and silently drop events.
+const SessionRecoveryProvided = SessionRecoveryStoreLayer.pipe(
+  Layer.provide(PathsLayer),
+  Layer.provide(PlatformLayer),
+);
 const HarnessSessionManagerProvided = HarnessAgentSessionManagerLayer.pipe(
   Layer.provide(RegistryLayer),
   Layer.provide(EventBusLayer),
+  Layer.provide(SessionRecoveryProvided),
   Layer.provide(PlatformLayer),
 );
 const HarnessSessionServiceProvided = HarnessAgentSessionServiceLayer.pipe(
   Layer.provide(HarnessSessionManagerProvided),
   Layer.provide(RegistryLayer),
   Layer.provide(EventBusLayer),
+  Layer.provide(SessionRecoveryProvided),
   Layer.provide(PathsLayer),
   Layer.provide(PlatformLayer),
 );

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -182,6 +182,7 @@ export const sessionRouter = orpc.router({
         Effect.fail(
           errors.CONFLICT({ message: `a turn is already running in session ${e.sessionId}` }),
         ),
+      RecoveryRequired: (e) => Effect.fail(errors.CONFLICT({ message: e.message })),
     });
   }),
   steer: orpc.steer.effect(function* ({ input, errors }) {
@@ -204,7 +205,6 @@ export const sessionRouter = orpc.router({
         SessionClosed: (e) =>
           Effect.fail(errors.SESSION_NOT_ACTIVE({ message: `session ${e.sessionId} is closed` })),
         TurnAlreadyRunning: (e) => Effect.fail(errors.CONFLICT({ message: e.message })),
-        RecoveryRequired: (e) => Effect.fail(errors.CONFLICT({ message: e.message })),
         AgentOperationError: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
       }),
     );

--- a/packages/server/src/rpc/session.ts
+++ b/packages/server/src/rpc/session.ts
@@ -204,7 +204,24 @@ export const sessionRouter = orpc.router({
         SessionClosed: (e) =>
           Effect.fail(errors.SESSION_NOT_ACTIVE({ message: `session ${e.sessionId} is closed` })),
         TurnAlreadyRunning: (e) => Effect.fail(errors.CONFLICT({ message: e.message })),
+        RecoveryRequired: (e) => Effect.fail(errors.CONFLICT({ message: e.message })),
         AgentOperationError: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
+      }),
+    );
+  }),
+  acknowledgeRecovery: orpc.acknowledgeRecovery.effect(function* ({ input, errors }) {
+    const sessions = yield* HarnessAgentSessionService;
+    yield* sessions.acknowledgeRecovery(input.ref, input.recoveryId).pipe(
+      Effect.catchTags({
+        SessionNotFound: (e) =>
+          Effect.fail(errors.NOT_FOUND({ message: `session ${e.sessionId} not found` })),
+        SessionRefMismatch: (e) =>
+          Effect.fail(
+            errors.INVALID_ARGUMENT({ message: `ref mismatch for session ${e.sessionId}` }),
+          ),
+        StaleRecovery: (e) => Effect.fail(errors.CONFLICT({ message: e.message })),
+        StoreReadError: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
+        StoreWriteError: (e) => Effect.fail(errors.INTERNAL({ message: e.message })),
       }),
     );
   }),
@@ -276,13 +293,25 @@ export const sessionRouter = orpc.router({
   // after a server restart used to get that error on every snapshot and retry
   // forever, because nothing on the observation path could ever make it go
   // away.
-  getStatus: orpc.getStatus.effect(function* ({ input }) {
+  getStatus: orpc.getStatus.effect(function* ({ input, errors }) {
     const sessions = yield* HarnessAgentSessionService;
-    return yield* sessions.getStatus(input.ref);
+    return yield* sessions
+      .getStatus(input.ref)
+      .pipe(
+        Effect.catchTag("StoreReadError", (e) =>
+          Effect.fail(errors.INTERNAL({ message: e.message })),
+        ),
+      );
   }),
-  getSnapshot: orpc.getSnapshot.effect(function* ({ input }) {
+  getSnapshot: orpc.getSnapshot.effect(function* ({ input, errors }) {
     const sessions = yield* HarnessAgentSessionService;
-    return yield* sessions.getSnapshot(input.ref);
+    return yield* sessions
+      .getSnapshot(input.ref)
+      .pipe(
+        Effect.catchTag("StoreReadError", (e) =>
+          Effect.fail(errors.INTERNAL({ message: e.message })),
+        ),
+      );
   }),
 
   // events --------------------------------------------------------------------

--- a/packages/server/test/harness/session-fold.test.ts
+++ b/packages/server/test/harness/session-fold.test.ts
@@ -17,6 +17,22 @@ const event = (seq: number, body: SessionScopedEventBody): SessionScopedEvent =>
 });
 
 describe("session prompt projection", () => {
+  it("preserves the live phase when recovery acknowledgement races a turn start", () => {
+    let state = foldSessionEvent(
+      initialSessionState,
+      event(1, { type: "session.turn.started", turnId: "turn-1" }),
+    );
+    state = foldSessionEvent(
+      state,
+      event(2, { type: "session.recovery.acknowledged", recoveryId: "recovery-1" }),
+    );
+
+    expect(toSnapshot(ref, "stream-1", state).status).toEqual({
+      phase: "running",
+      activeTurnId: "turn-1",
+    });
+  });
+
   it("reveals the accepted running prompt when a newer candidate is rejected", () => {
     let state = foldSessionEvent(
       initialSessionState,

--- a/packages/server/test/harness/session-fold.test.ts
+++ b/packages/server/test/harness/session-fold.test.ts
@@ -113,7 +113,7 @@ describe("session prompt projection", () => {
       event(5, { type: "session.prompt.accepted", messageId: "steer-a", turnId: "turn-1" }),
     );
 
-    expect(toSnapshot(ref, state).acceptedPrompts).toEqual([
+    expect(toSnapshot(ref, "stream-1", state).acceptedPrompts).toEqual([
       {
         messageId: "steer-a",
         parts: [{ type: "text", text: "A" }],
@@ -132,7 +132,7 @@ describe("session prompt projection", () => {
       state,
       event(6, { type: "session.turn.ended", turnId: "turn-1", outcome: "completed" }),
     );
-    expect(toSnapshot(ref, state)).toMatchObject({
+    expect(toSnapshot(ref, "stream-1", state)).toMatchObject({
       acceptedPrompt: null,
       acceptedPrompts: [],
     });

--- a/packages/server/test/harness/session-recovery.test.ts
+++ b/packages/server/test/harness/session-recovery.test.ts
@@ -1,0 +1,355 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { PromptPart, SessionRef } from "@vibest/contract";
+import { Deferred, Effect, Fiber, FileSystem } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { makeSessionRecoveryStore } from "../../src/harness/session-recovery";
+import { NodePlatformLayer } from "../platform";
+
+const ref: SessionRef = {
+  projectId: "67c12f8a-e48f-4d0f-9c21-dbb1b8ef6cc8",
+  harnessAgentId: "pi",
+  sessionId: "session/../unsafe",
+};
+
+const parts: PromptPart[] = [
+  { type: "text", text: "keep this prompt" },
+  { type: "file", mediaType: "text/plain", url: "file:///tmp/a.txt", filename: "a.txt" },
+  { type: "data-inspector", data: [{ file: "src/a.ts", line: 4, column: 2 }] },
+];
+
+const submitted = {
+  type: "session.prompt.submitted" as const,
+  messageId: "message-1",
+  parts,
+};
+
+const run = <A, E>(program: Effect.Effect<A, E, FileSystem.FileSystem>) =>
+  Effect.runPromise(program.pipe(Effect.provide(NodePlatformLayer)));
+
+describe("SessionRecoveryStore", () => {
+  let directory: string;
+
+  beforeEach(async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), "vibest-recovery-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+
+  it("persists real prompt parts and only barriers a later boot", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const firstBoot = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+        yield* firstBoot.beforePublish(ref, submitted);
+
+        const currentBarrier = yield* firstBoot.barrier(ref);
+        const secondBoot = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-2",
+          Effect.succeed("recovery-2"),
+        );
+        const restartedBarrier = yield* secondBoot.barrier(ref);
+        return { currentBarrier, restartedBarrier, record: yield* secondBoot.read(ref) };
+      }),
+    );
+
+    expect(result.currentBarrier).toBeNull();
+    expect(result.restartedBarrier).toEqual({
+      recoveryId: "recovery-1",
+      reason: "server_restart",
+      prompts: [{ messageId: "message-1", parts }],
+    });
+    expect(result.record?.prompts[0]?.parts).toEqual(parts);
+    expect(await fs.readdir(directory)).toEqual(["project-67c12f8a-e48f-4d0f-9c21-dbb1b8ef6cc8"]);
+  });
+
+  it("rejects a stale acknowledgement without clearing the durable barrier", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const firstBoot = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+        yield* firstBoot.beforePublish(ref, submitted);
+        const secondBoot = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-2",
+          Effect.succeed("recovery-2"),
+        );
+        const error = yield* Effect.flip(secondBoot.acknowledge(ref, "wrong-recovery"));
+        return { error, barrier: yield* secondBoot.barrier(ref) };
+      }),
+    );
+
+    expect(result.error._tag).toBe("StaleRecovery");
+    expect(result.barrier?.recoveryId).toBe("recovery-1");
+  });
+
+  it("does not expose a recovery record through a mismatched harness ref", async () => {
+    const barrier = await run(
+      Effect.gen(function* () {
+        const firstBoot = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+        yield* firstBoot.beforePublish(ref, submitted);
+        const secondBoot = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-2",
+          Effect.succeed("recovery-2"),
+        );
+        return yield* secondBoot.barrier({ ...ref, harnessAgentId: "codex" });
+      }),
+    );
+
+    expect(barrier).toBeNull();
+  });
+
+  it("serializes public clear behind a compound prompt write", async () => {
+    const record = await run(
+      Effect.gen(function* () {
+        const idRequested = yield* Deferred.make<void>();
+        const releaseId = yield* Deferred.make<void>();
+        const store = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Deferred.succeed(idRequested, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseId)),
+            Effect.as("recovery-1"),
+          ),
+        );
+        const writeFiber = yield* Effect.forkChild(store.beforePublish(ref, submitted));
+        yield* Deferred.await(idRequested);
+        const clearFiber = yield* Effect.forkChild(store.clear(ref));
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(releaseId, undefined);
+        yield* Fiber.join(writeFiber);
+        yield* Fiber.join(clearFiber);
+        return yield* store.read(ref);
+      }),
+    );
+
+    expect(record).toBeNull();
+  });
+
+  it("fails closed when the persisted record is corrupt", async () => {
+    const file = path.join(
+      directory,
+      "project-67c12f8a-e48f-4d0f-9c21-dbb1b8ef6cc8",
+      "harness-pi",
+      "session-session%2F..%2Funsafe.json",
+    );
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, "{ not json", "utf8");
+
+    const error = await run(
+      Effect.gen(function* () {
+        const store = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-2",
+          Effect.succeed("recovery-2"),
+        );
+        return yield* Effect.flip(store.barrier(ref));
+      }),
+    );
+
+    expect(error._tag).toBe("StoreReadError");
+  });
+
+  it("keeps an unaccepted fallback prompt across the old turn end and clears its late steering receipt", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const store = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.submitted",
+          messageId: "initial-prompt",
+          parts: [{ type: "text", text: "initial" }],
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.submitted",
+          messageId: "fallback-prompt",
+          parts: [{ type: "text", text: "steer or start next" }],
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.accepted",
+          messageId: "initial-prompt",
+          turnId: "turn-old",
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.turn.ended",
+          turnId: "turn-old",
+          outcome: "completed",
+        });
+        const afterOldTurn = yield* store.read(ref);
+
+        // Pi/Codex can return a steering receipt after the native turn-ended
+        // event has already crossed the session stream. It belongs to the old
+        // turn and must settle only this fallback prompt, never recreate it.
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.accepted",
+          messageId: "fallback-prompt",
+          turnId: "turn-old",
+        });
+        return { afterOldTurn, afterLateFallbackReceipt: yield* store.read(ref) };
+      }),
+    );
+
+    expect(result.afterOldTurn).toMatchObject({
+      prompts: [
+        {
+          messageId: "fallback-prompt",
+          parts: [{ type: "text", text: "steer or start next" }],
+        },
+      ],
+      endedTurnIds: ["turn-old"],
+    });
+    expect(result.afterLateFallbackReceipt).toBeNull();
+  });
+
+  it("keeps an unaccepted prompt for a later turn instead of clearing it with the old turn", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const store = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.submitted",
+          messageId: "old-prompt",
+          parts: [{ type: "text", text: "old" }],
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.submitted",
+          messageId: "next-prompt",
+          parts: [{ type: "text", text: "next" }],
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.accepted",
+          messageId: "old-prompt",
+          turnId: "turn-old",
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.turn.ended",
+          turnId: "turn-old",
+          outcome: "completed",
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.accepted",
+          messageId: "next-prompt",
+          turnId: "turn-next",
+        });
+        const runningNext = yield* store.read(ref);
+        yield* store.beforePublish(ref, {
+          type: "session.turn.ended",
+          turnId: "turn-next",
+          outcome: "completed",
+        });
+        return { runningNext, afterNextTurn: yield* store.read(ref) };
+      }),
+    );
+
+    expect(result.runningNext?.prompts).toEqual([
+      {
+        messageId: "next-prompt",
+        parts: [{ type: "text", text: "next" }],
+        turnId: "turn-next",
+      },
+    ]);
+    expect(result.afterNextTurn).toBeNull();
+  });
+
+  it("bounds remembered ended turn ids while unresolved prompts remain", async () => {
+    const record = await run(
+      Effect.gen(function* () {
+        const store = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+        yield* store.beforePublish(ref, submitted);
+        for (let index = 0; index < 40; index += 1) {
+          yield* store.beforePublish(ref, {
+            type: "session.turn.ended",
+            turnId: `turn-${index}`,
+            outcome: "completed",
+          });
+        }
+        return yield* store.read(ref);
+      }),
+    );
+
+    expect(record?.endedTurnIds).toHaveLength(32);
+    expect(record?.endedTurnIds.at(0)).toBe("turn-8");
+    expect(record?.endedTurnIds.at(-1)).toBe("turn-39");
+  });
+
+  it("clears rejected and terminal prompts without recreating after a late acceptance", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const store = yield* makeSessionRecoveryStore(
+          directory,
+          "boot-1",
+          Effect.succeed("recovery-1"),
+        );
+
+        yield* store.beforePublish(ref, submitted);
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.rejected",
+          messageId: "message-1",
+          reason: "not accepted",
+        });
+        const afterRejected = yield* store.read(ref);
+
+        yield* store.beforePublish(ref, submitted);
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.accepted",
+          messageId: "message-1",
+          turnId: "turn-1",
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.turn.ended",
+          turnId: "turn-1",
+          outcome: "completed",
+        });
+        const afterTerminal = yield* store.read(ref);
+
+        yield* store.beforePublish(ref, submitted);
+        yield* store.beforePublish(ref, {
+          type: "session.turn.ended",
+          turnId: "turn-2",
+          outcome: "completed",
+        });
+        yield* store.beforePublish(ref, {
+          type: "session.prompt.accepted",
+          messageId: "message-1",
+          turnId: "turn-2",
+        });
+        const afterLateAcceptance = yield* store.read(ref);
+
+        return { afterRejected, afterTerminal, afterLateAcceptance };
+      }),
+    );
+
+    expect(result).toEqual({
+      afterRejected: null,
+      afterTerminal: null,
+      afterLateAcceptance: null,
+    });
+  });
+});

--- a/packages/server/test/harness/session-service.test.ts
+++ b/packages/server/test/harness/session-service.test.ts
@@ -15,7 +15,12 @@ import type {
 } from "../../src/harness/adapter";
 import { AgentOpenError, TurnAlreadyRunning } from "../../src/harness/errors";
 import { makeHarnessAgentRegistry } from "../../src/harness/registry";
+import { makeHarnessAgentSession } from "../../src/harness/session";
 import { makeHarnessAgentSessionManager } from "../../src/harness/session-manager";
+import {
+  makeSessionRecoveryStore,
+  type SessionRecoveryStoreShape,
+} from "../../src/harness/session-recovery";
 import {
   type HarnessAgentSessionRepositoryShape,
   makeHarnessAgentSessionRepository,
@@ -30,15 +35,19 @@ type Spy = {
   open: Array<{ cwd: string }>;
   resume: Array<{ sessionId: string; cwd: string | undefined }>;
   close: Array<string>;
+  promptCalls: number;
 };
 
 type Fixture = {
   readonly service: HarnessAgentSessionServiceShape;
   readonly repo: HarnessAgentSessionRepositoryShape;
   readonly bus: EventBusShape;
+  readonly recovery: SessionRecoveryStoreShape;
   readonly spy: Spy;
   readonly waitForPromptStart: Effect.Effect<void>;
   readonly releasePrompt: Effect.Effect<void>;
+  readonly waitForCloseStart: Effect.Effect<void>;
+  readonly releaseClose: Effect.Effect<void>;
   /**
    * A second service over the same storage and the same adapter — what a
    * server restart looks like from the session domain: the records survive,
@@ -75,15 +84,19 @@ describe("HarnessAgentSessionService", () => {
       // Runtime reacquisition fails before runtime.prompt is available.
       resumeFails?: boolean;
       steerFails?: boolean;
+      // Hold runtime.close until the test releases it.
+      closeWaits?: boolean;
     },
     program: (fixture: Fixture) => Effect.Effect<A, E, Scope.Scope | FileSystem.FileSystem>,
   ) =>
     Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const spy: Spy = { open: [], resume: [], close: [] };
+          const spy: Spy = { open: [], resume: [], close: [], promptCalls: 0 };
           const promptStarted = yield* Deferred.make<void>();
           const promptGate = yield* Deferred.make<void>();
+          const closeStarted = yield* Deferred.make<void>();
+          const closeGate = yield* Deferred.make<void>();
           let opened = 0;
           const turnEvents = (sessionId: string) => {
             if (opts.turn === undefined) return Stream.empty;
@@ -117,15 +130,21 @@ describe("HarnessAgentSessionService", () => {
             sessionId,
             harnessAgentId: "claude-code",
             events: turnEvents(sessionId),
-            prompt: opts.promptFails
-              ? () => Effect.fail(new TurnAlreadyRunning({ sessionId }))
-              : opts.promptWaits
-                ? () =>
-                    Deferred.succeed(promptStarted, undefined).pipe(
-                      Effect.andThen(Deferred.await(promptGate)),
-                      Effect.as({ turnId: "turn-1" }),
-                    )
-                : () => Effect.succeed({ turnId: "turn-1" }),
+            prompt: () =>
+              Effect.sync(() => {
+                spy.promptCalls += 1;
+              }).pipe(
+                Effect.andThen(
+                  opts.promptFails
+                    ? Effect.fail(new TurnAlreadyRunning({ sessionId }))
+                    : opts.promptWaits
+                      ? Deferred.succeed(promptStarted, undefined).pipe(
+                          Effect.andThen(Deferred.await(promptGate)),
+                          Effect.as({ turnId: "turn-1" }),
+                        )
+                      : Effect.succeed({ turnId: "turn-1" }),
+                ),
+              ),
             steer: (_expectedTurnId) =>
               opts.steerFails
                 ? Effect.fail(new TurnAlreadyRunning({ sessionId, turnId: "turn-other" }))
@@ -142,7 +161,15 @@ describe("HarnessAgentSessionService", () => {
             ...(opts.history !== undefined ? { getMessages: Effect.succeed(opts.history) } : {}),
             close: Effect.sync(() => {
               spy.close.push(sessionId);
-            }),
+            }).pipe(
+              Effect.andThen(
+                opts.closeWaits
+                  ? Deferred.succeed(closeStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(closeGate)),
+                    )
+                  : Effect.void,
+              ),
+            ),
           });
           const adapter = {
             id: "claude-code",
@@ -181,9 +208,19 @@ describe("HarnessAgentSessionService", () => {
           const build: Effect.Effect<Fixture, never, Scope.Scope | FileSystem.FileSystem> =
             Effect.gen(function* () {
               const bus = yield* makeEventBus();
-              const manager = yield* makeHarnessAgentSessionManager(registry, bus).pipe(
-                Effect.provideService(Crypto.Crypto, crypto),
+              const recovery = yield* makeSessionRecoveryStore(
+                path.join(home, "storage", "session-recovery"),
+                yield* crypto.randomUUIDv4.pipe(Effect.orDie),
+                crypto.randomUUIDv4.pipe(Effect.orDie),
               );
+              const manager = yield* makeHarnessAgentSessionManager(
+                registry,
+                bus,
+                (ref, streamId, eventBus) =>
+                  makeHarnessAgentSession(ref, streamId, eventBus, (eventRef, body) =>
+                    recovery.beforePublish(eventRef, body).pipe(Effect.orDie),
+                  ),
+              ).pipe(Effect.provideService(Crypto.Crypto, crypto));
               const repo = yield* makeHarnessAgentSessionRepository(
                 path.join(home, "storage", "sessions"),
               );
@@ -192,15 +229,19 @@ describe("HarnessAgentSessionService", () => {
                 registry,
                 repo,
                 bus,
+                recovery,
                 newSessionId: crypto.randomUUIDv4.pipe(Effect.orDie),
               });
               return {
                 service,
                 repo,
                 bus,
+                recovery,
                 spy,
                 waitForPromptStart: Deferred.await(promptStarted),
                 releasePrompt: Deferred.succeed(promptGate, undefined).pipe(Effect.asVoid),
+                waitForCloseStart: Deferred.await(closeStarted),
+                releaseClose: Deferred.succeed(closeGate, undefined).pipe(Effect.asVoid),
                 restart: build,
               };
             });
@@ -300,6 +341,77 @@ describe("HarnessAgentSessionService", () => {
     expect(closeSpy).toEqual(["native-1"]);
   });
 
+  it("serializes close behind an already-authorized prompt receipt", async () => {
+    const result = await run({ promptWaits: true }, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        const prompt = yield* Effect.forkChild(
+          fixture.service.prompt({
+            ref,
+            messageId: "prompt-before-close",
+            parts: [{ type: "text", text: "finish authorization first" }],
+          }),
+        );
+        yield* fixture.waitForPromptStart;
+        const close = yield* Effect.forkChild(fixture.service.close(ref));
+        yield* Effect.yieldNow;
+        const closeBeforeReceipt = close.pollUnsafe();
+        const recoveryBeforeReceipt = yield* fixture.recovery.read(ref);
+
+        yield* fixture.releasePrompt;
+        yield* Fiber.join(prompt);
+        yield* Fiber.join(close);
+        return {
+          closeBeforeReceipt,
+          recoveryBeforeReceipt,
+          metadata: yield* fixture.repo.read(ref.projectId, ref.sessionId),
+          recovery: yield* fixture.recovery.read(ref),
+          promptCalls: fixture.spy.promptCalls,
+        };
+      }),
+    );
+
+    expect(result.closeBeforeReceipt).toBeUndefined();
+    expect(result.recoveryBeforeReceipt?.prompts[0]?.messageId).toBe("prompt-before-close");
+    expect(result.metadata.sessionId).toBeTruthy();
+    expect(result.recovery).toBeNull();
+    expect(result.promptCalls).toBe(1);
+  });
+
+  it("lets a prompt waiting behind close create a newer recovery record after close clears", async () => {
+    const result = await run({ turn: "open", closeWaits: true }, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        const close = yield* Effect.forkChild(fixture.service.close(ref));
+        yield* fixture.waitForCloseStart;
+        const prompt = yield* Effect.forkChild(
+          fixture.service.prompt({
+            ref,
+            messageId: "prompt-after-close",
+            parts: [{ type: "text", text: "newer work" }],
+          }),
+        );
+        yield* Effect.yieldNow;
+        const promptWhileCloseHeld = prompt.pollUnsafe();
+
+        yield* fixture.releaseClose;
+        yield* Fiber.join(close);
+        yield* Fiber.join(prompt);
+        return {
+          promptWhileCloseHeld,
+          recovery: yield* fixture.recovery.read(ref),
+          promptCalls: fixture.spy.promptCalls,
+        };
+      }),
+    );
+
+    expect(result.promptWhileCloseHeld).toBeUndefined();
+    expect(result.recovery?.prompts).toMatchObject([
+      { messageId: "prompt-after-close", turnId: "turn-1" },
+    ]);
+    expect(result.promptCalls).toBe(1);
+  });
+
   it("delete closes the native session and removes its metadata", async () => {
     const result = await run({}, (fixture) =>
       Effect.gen(function* () {
@@ -311,6 +423,47 @@ describe("HarnessAgentSessionService", () => {
     );
     expect(result.closeSpy).toEqual(["native-1"]);
     expect(result.listed).toHaveLength(0);
+  });
+
+  it("serializes delete behind an already-authorized prompt receipt", async () => {
+    const result = await run({ promptWaits: true }, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        const prompt = yield* Effect.forkChild(
+          fixture.service.prompt({
+            ref,
+            messageId: "prompt-before-delete",
+            parts: [{ type: "text", text: "finish authorization first" }],
+          }),
+        );
+        yield* fixture.waitForPromptStart;
+        const deletion = yield* Effect.forkChild(fixture.service.delete(ref));
+        yield* Effect.yieldNow;
+        const deleteBeforeReceipt = deletion.pollUnsafe();
+        const metadataBeforeReceipt = yield* fixture.repo.read(ref.projectId, ref.sessionId);
+        const recoveryBeforeReceipt = yield* fixture.recovery.read(ref);
+
+        yield* fixture.releasePrompt;
+        yield* Fiber.join(prompt);
+        yield* Fiber.join(deletion);
+        const metadataError = yield* Effect.flip(fixture.repo.read(ref.projectId, ref.sessionId));
+        return {
+          deleteBeforeReceipt,
+          metadataBeforeReceipt,
+          recoveryBeforeReceipt,
+          metadataError,
+          recovery: yield* fixture.recovery.read(ref),
+          promptCalls: fixture.spy.promptCalls,
+        };
+      }),
+    );
+
+    expect(result.deleteBeforeReceipt).toBeUndefined();
+    expect(result.metadataBeforeReceipt.sessionId).toBeTruthy();
+    expect(result.recoveryBeforeReceipt?.prompts[0]?.messageId).toBe("prompt-before-delete");
+    expect(result.metadataError._tag).toBe("SessionNotFound");
+    expect(result.recovery).toBeNull();
+    expect(result.promptCalls).toBe(1);
   });
 
   it("list returns one summary per session, keyed by server sessionId", async () => {
@@ -401,9 +554,10 @@ describe("HarnessAgentSessionService", () => {
   ): Effect.Effect<void> =>
     Effect.gen(function* () {
       while (true) {
-        const turn = yield* fixture.service
-          .getSnapshot(ref)
-          .pipe(Effect.map((snapshot) => snapshot.activeTurn));
+        const turn = yield* fixture.service.getSnapshot(ref).pipe(
+          Effect.orDie,
+          Effect.map((snapshot) => snapshot.activeTurn),
+        );
         if (done(turn)) return;
         yield* Effect.sleep("10 millis");
       }
@@ -414,10 +568,20 @@ describe("HarnessAgentSessionService", () => {
       Effect.gen(function* () {
         const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
         yield* waitForTurn(fixture, ref, (turn) => turn !== null && !turn.complete);
+        yield* fixture.recovery.beforePublish(ref, {
+          type: "session.prompt.submitted",
+          messageId: "active-before-archive",
+          parts: [{ type: "text", text: "active" }],
+        });
         yield* fixture.service.archive(ref, true);
         const active = yield* fixture.service.list("proj-a", false);
         const archived = yield* fixture.service.list("proj-a", true);
-        return { active, archived, closed: fixture.spy.close.slice() };
+        return {
+          active,
+          archived,
+          closed: fixture.spy.close.slice(),
+          recovery: yield* fixture.recovery.read(ref),
+        };
       }),
     );
 
@@ -425,6 +589,7 @@ describe("HarnessAgentSessionService", () => {
     expect(result.archived).toHaveLength(1);
     expect(result.archived[0]?.status).toBeUndefined();
     expect(result.closed).toEqual(["native-1"]);
+    expect(result.recovery).toBeNull();
   });
 
   it("getMessages trims the last user segment while a turn is in flight", async () => {
@@ -550,6 +715,100 @@ describe("HarnessAgentSessionService", () => {
     // … and none of it started an agent. `open` is the one at create time.
     expect(result.spy.open).toHaveLength(1);
     expect(result.spy.resume).toEqual([]);
+  });
+
+  it("restores an unresolved turn as a fail-closed barrier until explicit acknowledgement", async () => {
+    const history: UIMessage[] = [
+      { id: "committed-user", role: "user", parts: [{ type: "text", text: "before restart" }] },
+    ];
+    const result = await run({ coldHistory: history, promptWaits: true }, (fixture) =>
+      Effect.gen(function* () {
+        const ref = yield* fixture.service.create("proj-a", "claude-code", "/tmp/vibest-app");
+        yield* Effect.forkScoped(
+          fixture.service.prompt({
+            ref,
+            messageId: "uncertain-message",
+            parts: [{ type: "text", text: "may have caused side effects" }],
+          }),
+        );
+        yield* fixture.waitForPromptStart;
+        const resumesBeforeRestart = fixture.spy.resume.length;
+
+        const restarted = yield* fixture.restart;
+        const status = yield* restarted.service.getStatus(ref);
+        const snapshot = yield* restarted.service.getSnapshot(ref);
+        const messages = yield* restarted.service.getMessages(ref, "/tmp/vibest-app");
+        const blocked = yield* Effect.flip(
+          restarted.service.prompt({
+            ref,
+            messageId: "must-not-run",
+            parts: [{ type: "text", text: "do not replay" }],
+          }),
+        );
+
+        const recoveryId = snapshot.recovery?.recoveryId;
+        if (recoveryId === undefined) return yield* Effect.die("missing recovery barrier");
+        const acknowledged = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const stream = yield* restarted.bus.subscribe({ kind: "session", ref });
+            const eventFiber = yield* Effect.forkChild(
+              Stream.runCollect(
+                Stream.take(
+                  Stream.filter(
+                    stream,
+                    (item) =>
+                      item.type === "event" && item.event.type === "session.recovery.acknowledged",
+                  ),
+                  1,
+                ),
+              ),
+            );
+            yield* restarted.service.acknowledgeRecovery(ref, recoveryId);
+            return Array.from(yield* Fiber.join(eventFiber))[0];
+          }),
+        );
+        const after = yield* restarted.service.getSnapshot(ref);
+        yield* fixture.releasePrompt;
+
+        return {
+          status,
+          snapshot,
+          messages,
+          blocked,
+          acknowledged,
+          after,
+          promptCalls: fixture.spy.promptCalls,
+          resumesBeforeRestart,
+          resumesAfterRecovery: fixture.spy.resume.length,
+        };
+      }),
+    );
+
+    expect(result.status).toEqual({ phase: "recovery_required" });
+    expect(result.snapshot).toMatchObject({
+      status: { phase: "recovery_required" },
+      recovery: {
+        reason: "server_restart",
+        prompts: [
+          {
+            messageId: "uncertain-message",
+            parts: [{ type: "text", text: "may have caused side effects" }],
+          },
+        ],
+      },
+      activeTurn: null,
+      pendingRequests: [],
+    });
+    expect(result.messages).toEqual(history);
+    expect(result.blocked._tag).toBe("RecoveryRequired");
+    expect(result.acknowledged).toMatchObject({
+      type: "event",
+      event: { type: "session.recovery.acknowledged" },
+    });
+    expect(result.after.recovery).toBeNull();
+    expect(result.after.status).toEqual({ phase: "idle" });
+    expect(result.promptCalls).toBe(1);
+    expect(result.resumesAfterRecovery).toBe(result.resumesBeforeRestart);
   });
 
   // `turn: "finished"` keeps the fake's event stream open, which is what a real

--- a/packages/server/test/observability/turn-log.test.ts
+++ b/packages/server/test/observability/turn-log.test.ts
@@ -31,7 +31,7 @@ layer(Layer.empty)("turn logging", (it) => {
   // the whole block.
   const session = Effect.gen(function* () {
     const bus = Context.get(yield* Layer.build(EventBusLayer), EventBus);
-    return yield* makeHarnessAgentSession(ref, bus);
+    return yield* makeHarnessAgentSession(ref, "stream-1", bus);
   });
 
   it.effect("logs the two bookends and nothing in between", () =>

--- a/packages/server/test/rpc-harness.ts
+++ b/packages/server/test/rpc-harness.ts
@@ -13,6 +13,7 @@ import {
   makeHarnessAgentRegistry,
   type HarnessAgentAdapter,
 } from "../src/harness";
+import { SessionRecoveryStoreLayer } from "../src/harness/session-recovery";
 import { ProjectModuleLayer } from "../src/project";
 import { NodePtySpawnerLayer, PtyManagerLayer, PtyServiceLayer } from "../src/pty";
 import type { RpcContext } from "../src/rpc/context";
@@ -32,17 +33,23 @@ export async function makeRpcTestHarness(
   const paths = Layer.provideMerge(layerPaths(home), NodePlatformLayer);
   const registryLayer = Layer.sync(HarnessAgentRegistry, () => makeHarnessAgentRegistry(adapters));
   // EventBusLayer is one reference so publish (manager/service) and subscribe
-  // (RPC) share the single bus instance; same for registryLayer.
+  // (RPC) share the single bus instance; same for registryLayer and recoveryLayer.
+  const recoveryLayer = SessionRecoveryStoreLayer.pipe(
+    Layer.provide(paths),
+    Layer.provide(NodePlatformLayer),
+  );
   const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(
     Layer.provide(
       HarnessAgentSessionManagerLayer.pipe(
         Layer.provide(registryLayer),
         Layer.provide(EventBusLayer),
+        Layer.provide(recoveryLayer),
         Layer.provide(NodePlatformLayer),
       ),
     ),
     Layer.provide(registryLayer),
     Layer.provide(EventBusLayer),
+    Layer.provide(recoveryLayer),
     Layer.provide(paths),
     Layer.provide(NodePlatformLayer),
   );

--- a/packages/server/test/rpc-session.test.ts
+++ b/packages/server/test/rpc-session.test.ts
@@ -21,6 +21,7 @@ import {
 import type { HarnessAgentAdapter, HarnessAgentRuntime } from "../src/harness/adapter";
 import { makeCodexAdapter, makeCodexAgent } from "../src/harness/codex";
 import { SessionClosed } from "../src/harness/errors";
+import { SessionRecoveryStoreLayer } from "../src/harness/session-recovery";
 import * as Observability from "../src/observability";
 import { ProjectRepositoryLayer, ProjectServiceLayer } from "../src/project";
 import { NodePtySpawnerLayer, PtyManagerLayer, PtyServiceLayer } from "../src/pty";
@@ -81,16 +82,22 @@ async function setup() {
 
   // EventBusLayer is one reference so publish (manager/service) and subscribe
   // (RPC) share the single bus instance.
+  const recoveryLayer = SessionRecoveryStoreLayer.pipe(
+    Layer.provide(pathsLayer),
+    Layer.provide(NodeServices.layer),
+  );
   const harnessSessionLayer = HarnessAgentSessionServiceLayer.pipe(
     Layer.provide(
       HarnessAgentSessionManagerLayer.pipe(
         Layer.provide(registryLayer),
         Layer.provide(EventBusLayer),
+        Layer.provide(recoveryLayer),
         Layer.provide(NodeServices.layer),
       ),
     ),
     Layer.provide(registryLayer),
     Layer.provide(EventBusLayer),
+    Layer.provide(recoveryLayer),
     Layer.provide(pathsLayer),
     Layer.provide(NodeServices.layer),
   );


### PR DESCRIPTION
## Summary

- durably record prompts whose turns have not reached a known terminal event
- expose prior-boot uncertainty as `recovery_required` instead of an apparently idle session
- reconcile committed harness history while blocking all new and queued prompt dispatch
- never automatically replay the uncertain prompt or claim active-turn continuation
- require explicit recovery acknowledgement before future queued work may run
- broadcast acknowledgement to every attached client
- show every uncertain prompt in a recovery notice and disable the composer until acknowledgement
- fail closed on corrupt recovery data
- document the distinction between session resume, recovery barrier, and real active-turn continuation

## Safety model

Acknowledgement means only that the user reviewed the available history and accepts starting future work. It does not assert that the old turn completed, failed, stopped, or produced no tool side effects.

Recovery records are written before prompt events are published. Rejections and terminal events clear only the prompt/turn correlations they account for, including steering/fallback ordering where `turn.ended` can precede `prompt.accepted`.

## Validation

- full `pnpm test`
- full `pnpm check`
- contract: 38 tests
- app: 161 tests
- server: 393 passed / 2 skipped
- desktop: 43 tests
- React Doctor: 100/100
- `git diff --check`
- independent safety review: no significant findings

### Real browser / Pi kill-during-tool E2E

- killed the API with `SIGKILL` while prompt A's `sleep 20` tool was still running
- confirmed the API port closed and the browser page did not reload
- after restart, recovery warning appeared and listed A as `Uncertain · 1`
- queued prompt B remained `Queued · 1`; composer was inert/disabled
- neither A nor B was executed automatically
- after explicit acknowledgement, B executed exactly once and returned `FUTURE_SECOND_DONE`
- Pi history showed exactly one A prompt/tool call and exactly one B prompt/reply

## Non-guarantees

- this does not continue the original in-flight native executor
- it cannot reconstruct an assistant reply the harness never persisted
- tools may have produced external side effects before the crash
- some harnesses may start a context process to read history, but no prompt is sent while recovery is blocked

## Stack

Depends on #249.
