### PR TITLE
Add Cursor Auto Cloud Agent environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "Cursor Auto",
+  "install": "bash -l -c 'pnpm install && pnpm build'",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "bash -l -c 'pnpm dev'",
+      "description": "Vite on 4190 proxying /api and /ws/rpc to the vibest server on 4180"
+    }
+  ],
+  "ports": [
+    { "name": "app", "port": 4190 },
+    { "name": "api", "port": 4180 }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.cursor/environment.json` so Cloud Agents for vibest boot with a consistent, repository-managed environment named **Cursor Auto**.

- **install**: `pnpm install && pnpm build` via login shell (Node 24 + corepack pnpm per `AGENTS.md`)
- **terminals**: `pnpm dev` — Vite on 4190 + server on 4180 via turbo
- **ports**: 4190 (app), 4180 (API)

Once merged, new Cloud Agents started from this repo will use this config instead of dashboard-only personal settings.

## Notes

- Claude Code replies still need `ANTHROPIC_API_KEY` and `VIBEST_CLAUDE_EXECUTABLE` as environment secrets (see `AGENTS.md` cloud section).
- After merge, trigger an environment build from the [environment dashboard](https://cursor.com/dashboard/cloud-agents/environments) so agents boot from a prebuilt snapshot.

## Test plan

- [ ] Merge and trigger environment build
- [ ] Start a fresh Cloud Agent; confirm install completes and `dev` terminal serves http://localhost:4190
- [ ] `curl http://127.0.0.1:4180/api/health` → `ok`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acff7e51-dee2-4a3a-bfc8-05e32c09c5d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acff7e51-dee2-4a3a-bfc8-05e32c09c5d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

