### PR TITLE
Show a loading spinner on running sidebar sessions

### DIFF
--- a/apps/app/src/features/projects/project-session-row.tsx
+++ b/apps/app/src/features/projects/project-session-row.tsx
@@ -3,6 +3,7 @@ import type { SessionSummary } from "@vibest/contract";
 import { SidebarMenuButton, SidebarMenuItem } from "@vibest/ui/components/sidebar";
 
 import { SessionActionsMenu } from "@/features/projects/session-actions-menu";
+import { SessionStatusIndicator } from "@/features/projects/session-status-indicator";
 
 /** One session row: open-session navigation plus composed session actions. */
 export function ProjectSessionRow({
@@ -29,14 +30,7 @@ export function ProjectSessionRow({
         }
       >
         <span className="truncate">{session.title ?? "New chat"}</span>
-        {/* Busy elsewhere too: status is server-derived, so a turn any client
-            is running shows here. requires_action keeps the turn open. */}
-        {(session.status?.phase === "running" || session.status?.phase === "requires_action") && (
-          <span
-            className="ms-auto size-2 shrink-0 animate-pulse rounded-full bg-emerald-500"
-            title="A turn is running in this session"
-          />
-        )}
+        <SessionStatusIndicator phase={session.status?.phase} />
       </SidebarMenuButton>
       <SessionActionsMenu isActive={isActive} session={session} />
     </SidebarMenuItem>

--- a/apps/app/src/features/projects/session-status-indicator.tsx
+++ b/apps/app/src/features/projects/session-status-indicator.tsx
@@ -1,0 +1,56 @@
+import type { SessionPhase } from "@vibest/contract";
+import { Spinner } from "@vibest/ui/components/spinner";
+
+const SLOT_CLASS = "ms-auto inline-flex size-3 shrink-0 items-center justify-center";
+
+/** Server-derived session phase after the title. Idle rows omit the slot. */
+export function SessionStatusIndicator({ phase }: { readonly phase: SessionPhase | undefined }) {
+  switch (phase) {
+    case "running":
+      return (
+        <span
+          className={SLOT_CLASS}
+          data-slot="session-status"
+          data-state="loading"
+          title="A turn is running in this session"
+        >
+          <Spinner className="size-3" aria-label="A turn is running in this session" />
+        </span>
+      );
+    case "requires_action":
+      return (
+        <span
+          className={SLOT_CLASS}
+          aria-hidden
+          data-slot="session-status"
+          data-state="requires-action"
+        >
+          <span className="bg-warning size-2 rounded-full" title="Waiting for your action" />
+        </span>
+      );
+    case "recovery_required":
+      return (
+        <span
+          className={SLOT_CLASS}
+          aria-hidden
+          data-slot="session-status"
+          data-state="recovery-required"
+        >
+          <span className="bg-warning size-2 rounded-full" title="This session needs recovery" />
+        </span>
+      );
+    case "crashed":
+      return (
+        <span className={SLOT_CLASS} aria-hidden data-slot="session-status" data-state="crashed">
+          <span className="bg-destructive size-2 rounded-full" title="Session crashed" />
+        </span>
+      );
+    case "idle":
+    case undefined:
+      return null;
+    default: {
+      const exhaustive: never = phase;
+      return exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Port of pie [#77](https://github.com/oxwen11/pie/pull/77). Running and `requires_action` shared one green pulse. Running is now the shared spinner; waiting, recovery, and crash get distinct dots. Idle rows stay empty.

`recovery_required` is vibest-only — pie has no such phase.

## Test plan

- [x] `oxlint --type-aware` on changed files
- [ ] Start a turn and confirm the sidebar row shows a spinner
- [ ] `requires_action` / `recovery_required` / `crashed` show warning or destructive dots


Made with [Cursor](https://cursor.com)