### PR TITLE
fix(pi): keep willRetry as a transient notice

### DIFF
--- a/apps/app/src/features/chat/components/chat-transcript.tsx
+++ b/apps/app/src/features/chat/components/chat-transcript.tsx
@@ -34,6 +34,7 @@ export function ChatTranscript() {
   const messages = useStore(store, (state) => state.session.messages);
   const status = useStore(store, (state) => state.session.status);
   const error = useStore(store, (state) => state.session.error);
+  const retryNotice = useStore(store, (state) => state.session.retryNotice);
   const pendingRequests = useStore(store, (state) => state.session.pendingRequests);
   const historyStatus = useStore(store, (state) => state.session.historyStatus);
   const lastIndex = messages.length - 1;
@@ -55,6 +56,7 @@ export function ChatTranscript() {
             />
           ))}
           {status === "submitted" && <Loader />}
+          {retryNotice && <div className="text-muted-foreground text-xs">{retryNotice}</div>}
           {error && <div className="text-destructive text-xs">{error.message}</div>}
           {pendingRequests.map((request) => (
             <AgentRequestView key={request.id} request={request} onRespond={respondToRequest} />

--- a/apps/app/src/features/chat/runtime/chat-outgoing.ts
+++ b/apps/app/src/features/chat/runtime/chat-outgoing.ts
@@ -30,6 +30,7 @@ export function pushUserMessage(
 ): boolean {
   if (state.session.messages.some((message) => message.id === messageId)) return false;
   state.session.messages.push(toUserMessage(messageId, parts));
+  state.session.retryNotice = undefined;
   state.session.error = undefined;
   return true;
 }
@@ -119,6 +120,7 @@ function maybeDispatchFollowUp(state: ChatDraft, effects: ChatEffects): void {
     state.session.messages.push(next.message);
   }
   state.session.status = "submitted";
+  state.session.retryNotice = undefined;
   state.session.error = undefined;
   addUnique(state.prompt.pendingMessageIds, next.message.id);
   state.prompt.boundaryOpen = false;

--- a/apps/app/src/features/chat/runtime/chat-session.ts
+++ b/apps/app/src/features/chat/runtime/chat-session.ts
@@ -1,6 +1,5 @@
 import type {
   ActivePromptSnapshot,
-  SessionMessageChunkEvent,
   SessionRuntimeSnapshot,
   SessionScopedEvent,
 } from "@vibest/contract";
@@ -131,12 +130,17 @@ export function hydrateSnapshot(
     pushUserMessage(state, prompt.messageId, prompt.parts);
   }
 
-  let latestError: SessionMessageChunkEvent | undefined;
+  // Error text and retry status are not part of the settled transcript
+  // floor. Replay them in order so a retry that later emits output (or a
+  // terminal error) wins. Ignore chunks older than a retained prompt: the
+  // runtime can hold a completed old turn beside a newer submitted prompt.
   for (const event of activeTurn?.chunks ?? []) {
-    if (event.seq > state.sync.cursor && event.chunk.type === "error") latestError = event;
-  }
-  if (latestError && (appliedPromptSeq === undefined || latestError.seq > appliedPromptSeq)) {
-    captureChunkError(state, latestError.chunk);
+    if (
+      event.seq > state.sync.cursor &&
+      (appliedPromptSeq === undefined || event.seq > appliedPromptSeq)
+    ) {
+      captureChunkError(state, event.chunk);
+    }
   }
 
   for (const turnId of state.turns.recoverTurnIds.slice()) {
@@ -279,7 +283,11 @@ export function applyEvent(
   switch (event.type) {
     case "session.message.chunk":
       captureChunkError(state, event.chunk);
-      if (!includesValue(state.turns.recoverTurnIds, event.turnId)) {
+      // Retry is UI status, not transcript — keep it out of the message fold.
+      if (
+        event.chunk.type !== "data-retry" &&
+        !includesValue(state.turns.recoverTurnIds, event.turnId)
+      ) {
         if (event.chunk.type === "error") addUnique(state.turns.erroredTurnIds, event.turnId);
         appendFold(state, effects, event.turnId, event.chunk);
       }
@@ -296,6 +304,7 @@ export function applyEvent(
       break;
     case "session.turn.ended": {
       finishFold(state, effects, event.turnId);
+      state.session.retryNotice = undefined;
       state.session.pendingRequests = [];
       if (
         event.outcome !== "completed" ||
@@ -322,6 +331,7 @@ export function applyEvent(
       break;
     case "session.crashed":
       for (const turnId of Object.keys(state.turns.folds)) abandonFold(state, effects, turnId);
+      state.session.retryNotice = undefined;
       state.session.pendingRequests = [];
       break;
   }
@@ -366,6 +376,7 @@ function terminate(
   state.session.pendingRequests = [];
   state.session.historyStatus = "settled";
   state.session.status = "error";
+  state.session.retryNotice = undefined;
   state.session.error = new Error(
     reason === "session_deleted" ? "Session deleted" : "Session closed",
   );

--- a/apps/app/src/features/chat/runtime/chat-state.ts
+++ b/apps/app/src/features/chat/runtime/chat-state.ts
@@ -49,6 +49,7 @@ export type ChatState = {
     historyStatus: HistoryStatus;
     status: ChatStatus;
     error: Error | undefined;
+    retryNotice: string | undefined;
     activeTurnId: string | null;
   };
   outgoing: OutgoingMessage[];
@@ -93,6 +94,7 @@ export function createChatState(): ChatState {
       historyStatus: "loading",
       status: "ready",
       error: undefined,
+      retryNotice: undefined,
       activeTurnId: null,
     },
     outgoing: [],

--- a/apps/app/src/features/chat/runtime/chat-turn.ts
+++ b/apps/app/src/features/chat/runtime/chat-turn.ts
@@ -3,6 +3,7 @@ import type { UIMessage, UIMessageChunk } from "ai";
 
 import type { ChatDraft, ChatEffects } from "./chat-runtime-types";
 import { addUnique, removeValue, type ChatState } from "./chat-state";
+import { retryNoticeFrom } from "./retry-notice";
 import { sanitizeTail } from "./sanitize-tail";
 
 export const hasFolds = (state: ChatState): boolean => Object.keys(state.turns.folds).length > 0;
@@ -69,7 +70,18 @@ export function appendFold(
 }
 
 export function captureChunkError(state: ChatDraft, chunk: UIMessageChunk): void {
-  if (chunk.type === "error") state.session.error = new Error(chunk.errorText);
+  const retryNotice = retryNoticeFrom(chunk);
+  if (retryNotice !== undefined) {
+    state.session.error = undefined;
+    state.session.retryNotice = retryNotice;
+    return;
+  }
+  if (chunk.type === "error") {
+    state.session.retryNotice = undefined;
+    state.session.error = new Error(chunk.errorText);
+    return;
+  }
+  if (state.session.retryNotice !== undefined) state.session.retryNotice = undefined;
 }
 
 export function replayActiveTurn(
@@ -94,6 +106,7 @@ export function replayActiveTurn(
     return;
   }
   for (const chunk of chunks) {
+    if (chunk.type === "data-retry") continue;
     if (chunk.type === "error") addUnique(state.turns.erroredTurnIds, activeTurn.turnId);
     appendFold(state, effects, activeTurn.turnId, chunk);
   }

--- a/apps/app/src/features/chat/runtime/chat.test.ts
+++ b/apps/app/src/features/chat/runtime/chat.test.ts
@@ -2044,6 +2044,106 @@ describe("Chat stream errors", () => {
     expect(transport.promptCalls.at(-1)?.parts).toEqual([{ type: "text", text: "retry" }]);
   });
 
+  it("shows a retry notice until the same turn resumes output", async () => {
+    const { chat, attach, live } = makeChat();
+    await attach({});
+
+    live(1, { type: "session.turn.started", turnId: "turn-1", phase: "running" });
+    live(2, {
+      type: "session.message.chunk",
+      turnId: "turn-1",
+      chunk: {
+        type: "data-retry",
+        transient: true,
+        data: { errorMessage: "Connection error." },
+      },
+    });
+    expect(chat.store.getState().session.retryNotice).toBe(
+      "Couldn't reach the model provider. Retrying…",
+    );
+    expect(chat.store.getState().session.error).toBeUndefined();
+
+    live(3, {
+      type: "session.message.chunk",
+      turnId: "turn-1",
+      chunk: { type: "text-start", id: "retry-text" },
+    });
+    expect(chat.store.getState().session.retryNotice).toBeUndefined();
+  });
+
+  it("replaces a retry notice with a terminal provider error", async () => {
+    const { chat, attach, live } = makeChat();
+    await attach({});
+
+    live(1, {
+      type: "session.message.chunk",
+      turnId: "turn-1",
+      chunk: {
+        type: "data-retry",
+        transient: true,
+        data: { errorMessage: "overloaded", attempt: 1, maxAttempts: 3 },
+      },
+    });
+    expect(chat.store.getState().session.retryNotice).toBe("overloaded. Retrying (1/3)…");
+
+    live(2, {
+      type: "session.message.chunk",
+      turnId: "turn-1",
+      chunk: { type: "error", errorText: "overloaded" },
+    });
+    expect(chat.store.getState().session.retryNotice).toBeUndefined();
+    expect(chat.store.getState().session.error?.message).toBe("overloaded");
+  });
+
+  it("restores a retry notice from a live retained turn", async () => {
+    const { chat, attach } = makeChat();
+    await attach({ cursor: 1 });
+
+    await attach({
+      status: { phase: "running" },
+      recovery: null,
+      activeTurn: activeTurn({
+        turnId: "turn-1",
+        chunks: [
+          chunkEvent(2, "turn-1", {
+            type: "data-retry",
+            transient: true,
+            data: { errorMessage: "Connection error." },
+          }),
+        ],
+      }),
+      cursor: 2,
+    });
+
+    expect(chat.store.getState().session.retryNotice).toBe(
+      "Couldn't reach the model provider. Retrying…",
+    );
+  });
+
+  it("does not restore a retry notice after the retained turn has resumed", async () => {
+    const { chat, attach } = makeChat();
+    await attach({ cursor: 1 });
+
+    await attach({
+      status: { phase: "running" },
+      recovery: null,
+      activeTurn: activeTurn({
+        turnId: "turn-1",
+        chunks: [
+          chunkEvent(2, "turn-1", {
+            type: "data-retry",
+            transient: true,
+            data: { errorMessage: "Connection error." },
+          }),
+          chunkEvent(3, "turn-1", { type: "text-start", id: "retry-text" }),
+        ],
+      }),
+      cursor: 3,
+    });
+
+    expect(chat.store.getState().session.retryNotice).toBeUndefined();
+  });
+
   it("restores an unseen provider error after its retained prompt boundary", async () => {
     const { chat, attach } = makeChat();
     const providerError = "Connection error.";

--- a/apps/app/src/features/chat/runtime/retry-notice.test.ts
+++ b/apps/app/src/features/chat/runtime/retry-notice.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { retryNoticeFrom } from "./retry-notice";
+
+describe("retryNoticeFrom", () => {
+  it("rewrites a provider connection failure", () => {
+    expect(
+      retryNoticeFrom({
+        type: "data-retry",
+        transient: true,
+        data: { errorMessage: "Connection error." },
+      }),
+    ).toBe("Couldn't reach the model provider. Retrying…");
+  });
+
+  it("includes attempt counts when Pi reports them", () => {
+    expect(
+      retryNoticeFrom({
+        type: "data-retry",
+        transient: true,
+        data: { errorMessage: "overloaded", attempt: 1, maxAttempts: 3 },
+      }),
+    ).toBe("overloaded. Retrying (1/3)…");
+  });
+
+  it("ignores non-retry chunks", () => {
+    expect(retryNoticeFrom({ type: "error", errorText: "boom" })).toBeUndefined();
+  });
+});

--- a/apps/app/src/features/chat/runtime/retry-notice.ts
+++ b/apps/app/src/features/chat/runtime/retry-notice.ts
@@ -1,0 +1,26 @@
+import type { UIMessageChunk } from "ai";
+
+function retryField(data: unknown, key: string): unknown {
+  if (typeof data !== "object" || data === null || !(key in data)) return undefined;
+  return Reflect.get(data, key);
+}
+
+/** Transient Pi retry copy. Not an Error — the turn is still open. */
+export function retryNoticeFrom(chunk: UIMessageChunk): string | undefined {
+  if (chunk.type !== "data-retry") return undefined;
+  const data = "data" in chunk ? chunk.data : undefined;
+  const errorMessage = retryField(data, "errorMessage");
+  const reason =
+    errorMessage === "Connection error."
+      ? "Couldn't reach the model provider"
+      : typeof errorMessage === "string"
+        ? errorMessage
+        : "";
+  const attempt = retryField(data, "attempt");
+  const maxAttempts = retryField(data, "maxAttempts");
+  const suffix =
+    typeof attempt === "number" && typeof maxAttempts === "number"
+      ? `Retrying (${attempt}/${maxAttempts})…`
+      : "Retrying…";
+  return reason ? `${reason}. ${suffix}` : suffix;
+}

--- a/packages/server/src/harness/pi/transform.ts
+++ b/packages/server/src/harness/pi/transform.ts
@@ -23,8 +23,9 @@ import type { PiUIMessageChunk } from "./ui-message";
 //   • tool_execution_start/end → tool-input-available + tool-output-available.
 //     The AI-SDK tool chunks are generic, so args/results forward whole; the
 //     PiTools types still discriminate `message.parts` downstream.
-//   • message_end / compaction / auto-retry → skipped; no `data-*` parts on
-//     the chunk track
+//   • message_end / compaction / auto_retry_end → skipped
+//   • willRetry / auto_retry_start → transient `data-retry` (UI status, not
+//     transcript)
 //   • agent_start/agent_settled → `start`/`finish`; a retry re-emits
 //     agent_start, so `start` is guarded to fire once per turn.
 
@@ -191,13 +192,32 @@ export function createPiTransform(
       case "agent_end": {
         // A model-level failure surfaces as the run's last assistant message
         // with stopReason "error". willRetry keeps the turn open (the retry
-        // events follow); the terminal finish always comes from agent_settled.
+        // events follow): emit a transient retry chunk so the UI can show it,
+        // and only a terminal failure becomes an error chunk. The finish
+        // always comes from agent_settled.
         const last = event.messages.at(-1) as AssistantMessage | undefined;
         if (last?.role === "assistant" && last.stopReason === "error") {
-          yield { type: "error", errorText: last.errorMessage ?? "Pi run failed" };
+          const errorMessage = last.errorMessage ?? "Pi run failed";
+          if (event.willRetry) {
+            yield { type: "data-retry", transient: true, data: { errorMessage } };
+          } else {
+            yield { type: "error", errorText: errorMessage };
+          }
         }
         break;
       }
+
+      case "auto_retry_start":
+        yield {
+          type: "data-retry",
+          transient: true,
+          data: {
+            errorMessage: event.errorMessage,
+            attempt: event.attempt,
+            maxAttempts: event.maxAttempts,
+          },
+        };
+        break;
 
       case "agent_settled":
         if (turnOpen) {
@@ -224,7 +244,6 @@ export function createPiTransform(
           | "thinking_level_changed"
           | "compaction_start"
           | "compaction_end"
-          | "auto_retry_start"
           | "auto_retry_end");
     }
   };

--- a/packages/server/src/harness/pi/ui-message.ts
+++ b/packages/server/src/harness/pi/ui-message.ts
@@ -22,10 +22,15 @@ export type PiMetadata = {
   usage?: PiAssistantHistoryMessage["usage"];
 };
 
-// No `data-*` parts (mirrors codex/ui-message.ts) — assistant summaries,
-// compaction, and retry events stay off the chunk track until a data part
-// earns its keep.
-export type PiDataTypes = Record<never, never>;
+// Retry is transient UI status, not transcript. Compaction and assistant
+// summaries stay off the chunk track.
+export type PiDataTypes = {
+  retry: {
+    errorMessage: string;
+    attempt?: number;
+    maxAttempts?: number;
+  };
+};
 
 export type PiUIMessage = UIMessage<PiMetadata, PiDataTypes, PiTools>;
 export type PiUIMessageChunk = InferUIMessageChunk<PiUIMessage>;

--- a/packages/server/test/harness/pi/transform.test.ts
+++ b/packages/server/test/harness/pi/transform.test.ts
@@ -193,16 +193,48 @@ describe("createPiTransform", () => {
     expect(types([...t(e({ type: "agent_settled" }))])).toEqual(["finish"]);
   });
 
-  it("skips compaction and retry lifecycles", () => {
+  it("emits a transient retry chunk when Pi will retry a run error", () => {
+    const t = createPiTransform("s1");
+    const run = (event: AgentSessionEvent) => [...t(event)];
+    run(e({ type: "agent_start" }));
+    const failed = assistant({ stopReason: "error", errorMessage: "Connection error." });
+    expect(run(e({ type: "agent_end", messages: [failed], willRetry: true }))).toEqual([
+      {
+        type: "data-retry",
+        transient: true,
+        data: { errorMessage: "Connection error." },
+      },
+    ]);
+    expect(types(run(e({ type: "agent_settled" })))).toEqual(["finish"]);
+  });
+
+  it("forwards auto-retry attempts as transient retry chunks", () => {
+    const t = createPiTransform("s1");
+    expect([
+      ...t(
+        e({
+          type: "auto_retry_start",
+          attempt: 1,
+          maxAttempts: 3,
+          delayMs: 10,
+          errorMessage: "overloaded",
+        }),
+      ),
+    ]).toEqual([
+      {
+        type: "data-retry",
+        transient: true,
+        data: { errorMessage: "overloaded", attempt: 1, maxAttempts: 3 },
+      },
+    ]);
+    expect([...t(e({ type: "auto_retry_end", success: true, attempt: 1 }))]).toEqual([]);
+  });
+
+  it("skips compaction and retry-end lifecycles", () => {
     const t = createPiTransform("s1");
     expect([...t(e({ type: "compaction_start", reason: "threshold" }))]).toEqual([]);
     expect([
       ...t(e({ type: "compaction_end", reason: "threshold", result: undefined, aborted: false })),
-    ]).toEqual([]);
-    expect([
-      ...t(
-        e({ type: "auto_retry_start", attempt: 1, maxAttempts: 3, delayMs: 10, errorMessage: "x" }),
-      ),
     ]).toEqual([]);
     expect([...t(e({ type: "auto_retry_end", success: true, attempt: 1 }))]).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- Port of [pie#29](https://github.com/oxwen11/pie/pull/29): when Pi reports `willRetry` / `auto_retry_start`, emit a transient `data-retry` chunk instead of a terminal error.
- The chat runtime shows muted retry copy and clears it when the same turn resumes or fails for good — so a successful retry no longer leaves a stale red error.

## Test plan
- [x] `turbo run test --filter=@vibest/server -- harness/pi/transform.test.ts`
- [x] `turbo run test --filter=@vibest/app -- runtime/retry-notice.test.ts runtime/chat.test.ts`
- [ ] Live: trigger a Pi connection / overload retry and confirm the muted notice, then a successful continuation with no leftover error card


Made with [Cursor](https://cursor.com)