### PR TITLE
Forbid disable comments on React effect rules

### DIFF
--- a/.agents/rules/frontend-state.md
+++ b/.agents/rules/frontend-state.md
@@ -11,9 +11,10 @@ files are vendored or ported from upstream (`docs/adr/0001`), so a fix there is
 discarded on the next refresh and belongs upstream instead. A host-pushed value
 is a `useSyncExternalStore` source, not an effect — give the feed a
 `getSnapshot` (`ServerStatusFeed` is the shape to copy) rather than mirroring it
-into `useState`. An effect the rules genuinely misread — an editor's lifetime,
-say — gets an `eslint-disable-next-line` on the line the rule anchors to (the
-`setState` call, not always the `useEffect`) plus a sentence saying why.
+into `useState`. `vibest/no-restricted-disable` forbids `eslint-disable` /
+`oxlint-disable` comments on these nine rules and on `react/exhaustive-deps`
+(`react-hooks/exhaustive-deps` too): rewrite the effect or the store instead of
+silencing the diagnostic. A blanket `eslint-disable` is the same violation.
 
 ## Where a file goes
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,6 +12,7 @@
   "rules": {
     "unicorn/prefer-node-protocol": "error",
     "vibest/node-import-style": "error",
+    "vibest/no-restricted-disable": "error",
     "react/exhaustive-deps": [
       "error",
       {

--- a/apps/app/src/components/layout/shell-panels.tsx
+++ b/apps/app/src/components/layout/shell-panels.tsx
@@ -1,6 +1,13 @@
 import { useSidebar } from "@vibest/ui/components/sidebar";
 import { cn } from "@vibest/ui/lib/utils";
-import { type ReactNode, type RefObject, useEffect, useMemo, useRef } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import {
   Group,
   Panel,
@@ -91,25 +98,25 @@ function useCollapsedBinding(
 ): OnPanelResize {
   const laidOut = useRef(false);
 
-  const sync = (panel: PanelImperativeHandle): void => {
-    if (collapsed === panel.isCollapsed()) return;
-    if (collapsed) {
-      panel.collapse();
-      return;
-    }
-    panel.expand();
-    if (panel.isCollapsed()) panel.resize(expandedSize);
-  };
+  const sync = useCallback(
+    (panel: PanelImperativeHandle): void => {
+      if (collapsed === panel.isCollapsed()) return;
+      if (collapsed) {
+        panel.collapse();
+        return;
+      }
+      panel.expand();
+      if (panel.isCollapsed()) panel.resize(expandedSize);
+    },
+    [collapsed, expandedSize],
+  );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const panel = panelRef.current;
     // The imperative handle is only safe after the panel's first layout.
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (panel === null || !laidOut.current) return;
     sync(panel);
-    // `sync` closes over the current `collapsed` value.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collapsed, panelRef]);
+  }, [collapsed, panelRef, sync]);
 
   return (size) => {
     const panel = panelRef.current;

--- a/apps/app/src/features/chat/components/input/chat-input-controller.test.ts
+++ b/apps/app/src/features/chat/components/input/chat-input-controller.test.ts
@@ -45,7 +45,7 @@ describe("ChatInputController", () => {
   });
 
   // The state React hands the committed `useSyncExternalStore` snapshot when a
-  // route match suspends: the controller effect's cleanup has already disposed
+  // route match suspends: the controller store's unsubscribe has already disposed
   // this instance, but the last committed render still closes over it. Reading
   // the destroyed editor is what threw `Cannot read properties of null
   // (reading 'extensions')` — `Editor.destroy()` nulls `extensionManager`, and

--- a/apps/app/src/features/chat/components/input/chat-input-controller.ts
+++ b/apps/app/src/features/chat/components/input/chat-input-controller.ts
@@ -41,7 +41,7 @@ export class ChatInputController {
    *
    * A disposed controller answers `false` rather than throwing: React can hand
    * a `useSyncExternalStore` snapshot the outgoing controller *after* this
-   * effect's cleanup has already run (see `useChatInputHasContent`), and
+   * store's unsubscribe has already run (see `useChatInputHasContent`), and
    * "destroyed editor" is genuinely "nothing to send".
    */
   hasContent(): boolean {

--- a/apps/app/src/features/chat/components/input/use-chat-input-controller.ts
+++ b/apps/app/src/features/chat/components/input/use-chat-input-controller.ts
@@ -1,33 +1,40 @@
-import { useEffect, useState } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 
 import { useLatestRef } from "@/hooks/use-latest-ref";
 
 import { ChatInputController, type ChatInputControllerOptions } from "./chat-input-controller";
 
-// Create the controller inside an effect (under StrictMode each effect run
-// creates and disposes its own instance — a destroyed editor is never reused);
-// callbacks go through a latest-ref so closures never see stale state. First
+const getServerSnapshot = (): ChatInputController | null => null;
+
+// The controller is a store this hook owns: subscribe constructs it, the
+// unsubscribe disposes it. StrictMode subscribe/unsubscribe/subscribe creates
+// and destroys a throwaway instance — a destroyed editor is never reused.
+// Callbacks go through a latest-ref so closures never see stale state. First
 // render returns null — consumers must tolerate it.
 export function useChatInputController(
   opts: ChatInputControllerOptions,
 ): ChatInputController | null {
   const optsRef = useLatestRef(opts);
-  const [controller, setController] = useState<ChatInputController | null>(null);
-  useEffect(() => {
-    const created = new ChatInputController({
-      extensions: (self) => optsRef.current.extensions(self),
-      onSubmit: (text) => optsRef.current.onSubmit(text),
-    });
-    // Not an external-store subscription: the effect owns the controller's
-    // lifetime (a ProseMirror editor can't be constructed during render, and
-    // its teardown must run on unmount), so there is nothing to snapshot.
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-external-store-subscription
-    setController(created);
-    return () => {
-      setController(null);
-      created.dispose();
-    };
-    // optsRef is a stable ref; the controller's lifetime is bound to mount only.
-  }, [optsRef]);
-  return controller;
+  const storeRef = useRef<ChatInputController | null>(null);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const created = new ChatInputController({
+        extensions: (self) => optsRef.current.extensions(self),
+        onSubmit: (text) => optsRef.current.onSubmit(text),
+      });
+      storeRef.current = created;
+      onStoreChange();
+      return () => {
+        storeRef.current = null;
+        created.dispose();
+        onStoreChange();
+      };
+    },
+    [optsRef],
+  );
+
+  const getSnapshot = useCallback(() => storeRef.current, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/apps/app/src/features/chat/components/input/use-chat-input-has-content.test.ts
+++ b/apps/app/src/features/chat/components/input/use-chat-input-has-content.test.ts
@@ -69,9 +69,9 @@ describe("useChatInputHasContent", () => {
     controller.dispose();
   });
 
-  // The session-switch window: React tears the controller effect down and back
-  // up while this component stays mounted (a route match suspending on its
-  // loader, StrictMode, <Activity>), so one editor is destroyed and another
+  // The session-switch window: React tears the controller store subscription
+  // down and back up while this component stays mounted (a route match
+  // suspending on its loader, StrictMode, <Activity>), so one editor is destroyed and another
   // built between two renders of the same fiber. Both halves have to hold —
   // rendering the outgoing, already-disposed controller must not throw, and the
   // incoming one must be read immediately rather than waiting for its first

--- a/apps/app/src/features/chat/components/input/use-chat-input-has-content.ts
+++ b/apps/app/src/features/chat/components/input/use-chat-input-has-content.ts
@@ -15,10 +15,10 @@ const NO_UNSUBSCRIBE = () => {};
  * editor the controller has already destroyed — and `Editor.destroy()` nulls
  * `extensionManager`, which is the first thing serialization reads.
  *
- * That swap is not exotic: React tears the controller effect down and back up
- * while this component stays mounted (a route match suspending on its loader,
- * StrictMode, `<Activity>`), so `useChatInputController` disposes one editor
- * and builds another between two renders of the same fiber. Reading through
+ * That swap is not exotic: React tears the controller store subscription down
+ * and back up while this component stays mounted (a route match suspending on
+ * its loader, StrictMode, `<Activity>`), so `useChatInputController` disposes
+ * one editor and builds another between two renders of the same fiber. Reading through
  * the controller keeps that impossible — there is no editor reference held
  * across the swap — and it also drops the staleness the cache caused, where
  * the send button reflected the old editor until the new one first changed.

--- a/tools/oxlint/no-restricted-disable.mjs
+++ b/tools/oxlint/no-restricted-disable.mjs
@@ -1,0 +1,59 @@
+// Forbids eslint/oxlint disable comments on the React effect rules that
+// `.agents/rules/frontend-state.md` treats as non-negotiable. Rewrite the
+// effect (or the store) instead of silencing the diagnostic.
+
+const DISABLE_DIRECTIVE =
+  /^\s*(?<kind>oxlint|eslint)-disable(?<scope>-next-line|-line)?(?:\s+(?<body>[\s\S]*))?$/u;
+
+const PROTECTED_RULES = new Set([
+  "react/exhaustive-deps",
+  "react-hooks/exhaustive-deps",
+  "vibest/no-restricted-disable",
+]);
+
+const PROTECTED_PREFIXES = ["react-you-might-not-need-an-effect/"];
+
+const isProtectedRule = (rule) =>
+  PROTECTED_RULES.has(rule) || PROTECTED_PREFIXES.some((prefix) => rule.startsWith(prefix));
+
+const parseDisableDirective = (commentValue) => {
+  const match = DISABLE_DIRECTIVE.exec(commentValue.trim());
+  if (match?.groups === undefined) return null;
+  const rulePart = (match.groups.body ?? "").replace(/\s+--\s+[\s\S]*$/u, "").trim();
+  if (rulePart === "") return { rules: null };
+  const rules = rulePart
+    .split(",")
+    .map((part) => part.trim().split(/\s+/u)[0] ?? "")
+    .filter((name) => name.length > 0);
+  return { rules };
+};
+
+export const noRestrictedDisable = {
+  create(context) {
+    return {
+      Program() {
+        for (const comment of context.sourceCode.getAllComments()) {
+          const parsed = parseDisableDirective(comment.value);
+          if (parsed === null) continue;
+          if (parsed.rules === null) {
+            context.report({
+              node: comment,
+              message:
+                "A blanket eslint/oxlint-disable also turns off react-you-might-not-need-an-effect and react/exhaustive-deps. Name the other rules, or rewrite the React effect.",
+            });
+            continue;
+          }
+          for (const rule of parsed.rules) {
+            if (!isProtectedRule(rule)) continue;
+            context.report({
+              node: comment,
+              message: `Do not disable ${rule} with a comment. Rewrite the effect (or the store) instead of silencing the diagnostic.`,
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export { isProtectedRule, parseDisableDirective };

--- a/tools/oxlint/no-restricted-disable.test.mjs
+++ b/tools/oxlint/no-restricted-disable.test.mjs
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isProtectedRule, parseDisableDirective } from "./no-restricted-disable.mjs";
+
+describe("parseDisableDirective", () => {
+  it("ignores ordinary comments", () => {
+    expect(parseDisableDirective("not a disable directive")).toBeNull();
+  });
+
+  it("allows named disables that are not protected", () => {
+    const parsed = parseDisableDirective("oxlint-disable-next-line unicorn/no-array-sort -- fresh");
+    expect(parsed).toEqual({ rules: ["unicorn/no-array-sort"] });
+    expect(parsed.rules.every((rule) => !isProtectedRule(rule))).toBe(true);
+  });
+
+  it("treats a missing rule list as a blanket disable", () => {
+    expect(parseDisableDirective("eslint-disable")).toEqual({ rules: null });
+    expect(parseDisableDirective("oxlint-disable")).toEqual({ rules: null });
+  });
+
+  it("flags the React effect rules and exhaustive-deps aliases", () => {
+    expect(
+      parseDisableDirective(
+        "eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler",
+      ).rules,
+    ).toEqual(["react-you-might-not-need-an-effect/no-event-handler"]);
+    expect(isProtectedRule("react-you-might-not-need-an-effect/no-event-handler")).toBe(true);
+    expect(isProtectedRule("react-you-might-not-need-an-effect/no-external-store-subscription")).toBe(
+      true,
+    );
+    expect(isProtectedRule("react-hooks/exhaustive-deps")).toBe(true);
+    expect(isProtectedRule("react/exhaustive-deps")).toBe(true);
+    expect(isProtectedRule("vibest/no-restricted-disable")).toBe(true);
+  });
+
+  it("keeps only the rule name when a disable lists several", () => {
+    expect(parseDisableDirective("eslint-disable-next-line react/exhaustive-deps, no-console")).toEqual({
+      rules: ["react/exhaustive-deps", "no-console"],
+    });
+  });
+});

--- a/tools/oxlint/no-restricted-disable.test.mjs
+++ b/tools/oxlint/no-restricted-disable.test.mjs
@@ -25,16 +25,18 @@ describe("parseDisableDirective", () => {
       ).rules,
     ).toEqual(["react-you-might-not-need-an-effect/no-event-handler"]);
     expect(isProtectedRule("react-you-might-not-need-an-effect/no-event-handler")).toBe(true);
-    expect(isProtectedRule("react-you-might-not-need-an-effect/no-external-store-subscription")).toBe(
-      true,
-    );
+    expect(
+      isProtectedRule("react-you-might-not-need-an-effect/no-external-store-subscription"),
+    ).toBe(true);
     expect(isProtectedRule("react-hooks/exhaustive-deps")).toBe(true);
     expect(isProtectedRule("react/exhaustive-deps")).toBe(true);
     expect(isProtectedRule("vibest/no-restricted-disable")).toBe(true);
   });
 
   it("keeps only the rule name when a disable lists several", () => {
-    expect(parseDisableDirective("eslint-disable-next-line react/exhaustive-deps, no-console")).toEqual({
+    expect(
+      parseDisableDirective("eslint-disable-next-line react/exhaustive-deps, no-console"),
+    ).toEqual({
       rules: ["react/exhaustive-deps", "no-console"],
     });
   });

--- a/tools/oxlint/node-import-style.mjs
+++ b/tools/oxlint/node-import-style.mjs
@@ -1,5 +1,7 @@
 import module from "node:module";
 
+import { noRestrictedDisable } from "./no-restricted-disable.mjs";
+
 const { isBuiltin } = module;
 
 // Enforces the repo convention for Node builtin imports:
@@ -85,5 +87,6 @@ export default {
   meta: { name: "vibest" },
   rules: {
     "node-import-style": nodeImportStyle,
+    "no-restricted-disable": noRestrictedDisable,
   },
 };


### PR DESCRIPTION
## Summary

`vibest/no-restricted-disable` forbids `eslint-disable` / `oxlint-disable` comments that silence:

- any `react-you-might-not-need-an-effect/*` rule
- `react/exhaustive-deps` / `react-hooks/exhaustive-deps`
- a blanket `eslint-disable` / `oxlint-disable` (those turn the same rules off)

`.agents/rules/frontend-state.md` now requires rewriting the effect or the store instead of silencing the diagnostic.

Existing suppressions are rewritten:

- `useChatInputController` owns the editor through `useSyncExternalStore` (subscribe constructs, unsubscribe disposes)
- `useCollapsedBinding` (sidebar and chat columns) uses `useLayoutEffect` + `useCallback` so `no-event-handler` and `exhaustive-deps` no longer fire

Harness selector, per-agent tool UI, and `SessionRef.harnessAgentId` are unchanged.

Inspired by [oxwen11/pie#78](https://github.com/oxwen11/pie/pull/78). Reimplemented on vibest's `.mjs` oxlint plugin (`plugin` name `vibest`) rather than copying pie's oxlint package.

### Skipped

- pie's TypeScript oxlint package / RuleTester harness — vibest lints via root oxlint and `tools/oxlint/*.mjs`
- pie branding, Pi-only harness / registry removal
- Motion sidebar drawer from pie#72 — pie-only chrome, not this behavior

## Test plan

- [x] `oxlint --deny-warnings` on touched files
- [x] vitest on `tools/oxlint/no-restricted-disable.test.mjs` (5 tests)
- [x] `turbo run test --filter=@vibest/app` — 202 passed
- [x] Live oxlint on a snippet with a forbidden disable reports `vibest/no-restricted-disable`
- [x] react-doctor `--scope changed` — 100 / 100
- [ ] `turbo run typecheck --filter=@vibest/app` — same pre-existing `OutgoingMessage.delivery` error as on `main` (`chat-update.test.ts:421`)
